### PR TITLE
feat: Add interactive tutorial system for all pages

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1285,6 +1285,24 @@
                 "title": "Clickable Cells",
                 "description": "Click any cell to see shift details, or click an empty workday cell to submit a request such as vacation or working from home."
             }
+        },
+        "yearlyCalendar": {
+            "navigation": {
+                "title": "Navigate Years",
+                "description": "Use the arrows to step through years, or pick a specific year from the dropdown."
+            },
+            "balance": {
+                "title": "Yearly Balance",
+                "description": "Your total hours balance for the selected year. Green means you are ahead of your expected hours, orange means behind."
+            },
+            "calendar": {
+                "title": "Year at a Glance",
+                "description": "Each row is a month, each column a day. Colored badges show your logged hours by type. Weekends are dimmed and holidays are highlighted in orange."
+            },
+            "cell": {
+                "title": "Click a Day",
+                "description": "Click any day cell that has logged hours to see the detailed time entries recorded for that day."
+            }
         }
     }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -1267,6 +1267,24 @@
                 "title": "Task Actions",
                 "description": "Use the plus button to add a subtask, or the trash button to delete the task."
             }
+        },
+        "shifts": {
+            "navigation": {
+                "title": "Navigate Periods",
+                "description": "Use the arrows to move forward or backward by week or month. Click Today to jump back to the current period."
+            },
+            "viewToggle": {
+                "title": "Week and Month View",
+                "description": "Switch between a 7-day week view and a full month view. The calendar updates instantly."
+            },
+            "calendar": {
+                "title": "Shifts Calendar",
+                "description": "Each row is a team member. Each column is a day. Colored badges show where they are working — office, home, vacation, or sick leave."
+            },
+            "cell": {
+                "title": "Clickable Cells",
+                "description": "Click any cell to see shift details, or click an empty workday cell to submit a request such as vacation or working from home."
+            }
         }
     }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -1231,6 +1231,42 @@
                 "title": "Balance",
                 "description": "Your balance compares total logged hours against expected working hours for the selected period. Green means ahead, orange means behind."
             }
+        },
+        "tasks": {
+            "newTask": {
+                "title": "Create a Task",
+                "description": "Click to add a new task. You can assign it to a list, set a status, and start tracking time right away."
+            },
+            "groups": {
+                "title": "Task Groups",
+                "description": "Tasks are grouped by list. Only in-progress tasks appear here — switch to a list to see all statuses."
+            },
+            "timer": {
+                "title": "Time Tracking",
+                "description": "Press the play button to start tracking time on a task. Press stop when done. Only one task can run at a time."
+            },
+            "timeEntries": {
+                "title": "Time Entries",
+                "description": "Click the duration to view and edit individual entries. Useful for correcting start or end times after the fact."
+            }
+        },
+        "tasksList": {
+            "newTask": {
+                "title": "Create a Task",
+                "description": "Add a new task to this list. You can set its status, track time, and nest subtasks under it."
+            },
+            "statusSections": {
+                "title": "Status Sections",
+                "description": "Tasks are grouped by status. Click a section header to expand or collapse it."
+            },
+            "timer": {
+                "title": "Time Tracking",
+                "description": "Press the play button to start tracking time on a task. Press stop when done. Only one task can run at a time."
+            },
+            "actions": {
+                "title": "Task Actions",
+                "description": "Use the plus button to add a subtask, or the trash button to delete the task."
+            }
         }
     }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -1185,5 +1185,12 @@
         "title": "Time Manager",
         "description": "Manage your time, tasks, and hours efficiently",
         "company": "Acme Corporation"
+    },
+    "tutorial": {
+        "next": "Next",
+        "previous": "Previous",
+        "done": "Got it",
+        "skip": "Skip tour",
+        "progress": "{{current}} of {{total}}"
     }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -1213,6 +1213,24 @@
                 "title": "Time Entries",
                 "description": "View all individual time entries logged today for the selected task."
             }
+        },
+        "timeSheets": {
+            "table": {
+                "title": "Time Sheets",
+                "description": "This page shows all tasks you tracked time on, with daily totals organized by the selected week or month."
+            },
+            "taskCell": {
+                "title": "Task Time Entries",
+                "description": "Click any duration on a task row to view its entries. You can adjust start and end times — the duration updates instantly. Useful if you forgot to start tracking, or need to correct a time."
+            },
+            "dateCell": {
+                "title": "Clickable Totals",
+                "description": "Click any hours number in a date column to see all individual time entries recorded that day."
+            },
+            "balance": {
+                "title": "Balance",
+                "description": "Your balance compares total logged hours against expected working hours for the selected period. Green means ahead, orange means behind."
+            }
         }
     }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -1303,6 +1303,28 @@
                 "title": "Click a Day",
                 "description": "Click any day cell that has logged hours to see the detailed time entries recorded for that day."
             }
+        },
+        "hours": {
+            "summary": {
+                "title": "Hours Summary",
+                "description": "A quick overview of your total logged hours, balance vs expected, and a breakdown by hour type for both the current week and month."
+            },
+            "navigation": {
+                "title": "Navigate Periods",
+                "description": "Step through weeks or months with the arrows, and switch between week and month view with the buttons on the right."
+            },
+            "addEntry": {
+                "title": "Add Hours",
+                "description": "Manually log hours for a date range. Choose an hour type, pick dates, and enter the number of hours."
+            },
+            "table": {
+                "title": "Hours Table",
+                "description": "Each row is an hour type (Work, Vacation, Sick Leave, etc.). Each column is a day. The top row shows your total hours per day across all types."
+            },
+            "editCell": {
+                "title": "Edit Hours Inline",
+                "description": "Click any cell in a MANUAL row to set hours directly. Changes are batched and saved together when you click Save."
+            }
         }
     }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -1320,10 +1320,6 @@
             "table": {
                 "title": "Hours Table",
                 "description": "Each row is an hour type (Work, Vacation, Sick Leave, etc.). Each column is a day. The top row shows your total hours per day across all types."
-            },
-            "editCell": {
-                "title": "Edit Hours Inline",
-                "description": "Click any cell in a MANUAL row to set hours directly. Changes are batched and saved together when you click Save."
             }
         }
     }

--- a/messages/en.json
+++ b/messages/en.json
@@ -121,7 +121,8 @@
         "menu": {
             "settings": "Settings",
             "language": "Language",
-            "theme": "Theme"
+            "theme": "Theme",
+            "restartTutorial": "Restart tutorial"
         },
         "notifications": {
             "title": "Notifications",
@@ -1191,6 +1192,23 @@
         "previous": "Previous",
         "done": "Got it",
         "skip": "Skip tour",
-        "progress": "{{current}} of {{total}}"
+        "tracker": {
+            "hourType": {
+                "title": "Hour Type",
+                "description": "Select the type of time you are tracking — work, break, or private."
+            },
+            "taskSelect": {
+                "title": "Task",
+                "description": "Optionally link your tracked time to a specific in-progress task."
+            },
+            "timerButton": {
+                "title": "Start / Stop Timer",
+                "description": "Press to start tracking time. Press again to stop and save the entry."
+            },
+            "dailySummary": {
+                "title": "Daily Summary",
+                "description": "A live breakdown of your tracked, manual, and total hours for today."
+            }
+        }
     }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -1208,6 +1208,10 @@
             "dailySummary": {
                 "title": "Daily Summary",
                 "description": "A live breakdown of your tracked, manual, and total hours for today."
+            },
+            "timeEntries": {
+                "title": "Time Entries",
+                "description": "View all individual time entries logged today for the selected task."
             }
         }
     }

--- a/messages/en.json
+++ b/messages/en.json
@@ -1321,6 +1321,20 @@
                 "title": "Hours Table",
                 "description": "Each row is an hour type (Work, Vacation, Sick Leave, etc.). Each column is a day. The top row shows your total hours per day across all types."
             }
+        },
+        "requests": {
+            "controls": {
+                "title": "Filter and Create",
+                "description": "Use the search box to filter your requests by type, date, or status. Click New Request to submit a new leave or work request."
+            },
+            "newRequest": {
+                "title": "New Request",
+                "description": "Opens the request form where you can choose the type (vacation, sick leave, work from home, etc.), select dates, and optionally add a reason."
+            },
+            "table": {
+                "title": "Your Requests",
+                "description": "All your submitted requests are listed here with their type, dates, hours, and current status. Double-click any row to view or edit a pending request."
+            }
         }
     }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -487,6 +487,7 @@
             "viewRequestHistory": "View Request History",
             "recentPendingRequests": "Recent Pending Requests",
             "recentPendingRequestsDesc": "Latest requests awaiting your approval",
+            "noPendingRequests": "No pending requests",
             "upcomingHolidaysSection": "Upcoming Holidays",
             "upcomingHolidaysSectionDesc": "Next scheduled holidays",
             "viewAllPending": "View all {count} pending requests",
@@ -1376,6 +1377,104 @@
             "table": {
                 "title": "Daily Hours Table",
                 "description": "Each row is one working day. Columns show clock-in, clock-out, attendance hours, accounted hours, and running day, month, and year balances."
+            }
+        },
+        "adminOverview": {
+            "stats": {
+                "title": "Overview Statistics",
+                "description": "At a glance: total users, pending requests, upcoming holidays, and active task lists."
+            },
+            "statusBreakdown": {
+                "title": "Request Status Breakdown",
+                "description": "Counts of all requests by status: pending, approved, rejected, and cancelled."
+            },
+            "quickActions": {
+                "title": "Quick Actions",
+                "description": "Shortcuts to the most common admin tasks — manage users, review pending requests, manage holidays, and view request history."
+            },
+            "recentRequests": {
+                "title": "Recent Pending Requests",
+                "description": "The five most recent requests that are still waiting for your approval."
+            },
+            "upcomingHolidays": {
+                "title": "Upcoming Holidays",
+                "description": "The next scheduled holidays. Click View All to manage the full holiday list."
+            }
+        },
+        "adminUsers": {
+            "toolbar": {
+                "title": "Search and Create Users",
+                "description": "Filter users by name, toggle showing deactivated accounts, or open the menu to create a new user or export the list."
+            },
+            "table": {
+                "title": "User List",
+                "description": "All users with their role and status. Double-click a row to open the user's detail page."
+            }
+        },
+        "adminUserDetail": {
+            "editForm": {
+                "title": "Edit User Profile",
+                "description": "Update the user's name, email, role, work hours, and account status. Changes take effect immediately."
+            },
+            "hours": {
+                "title": "User Hours & Tracking",
+                "description": "View and edit the user's manual and tracked hours for the current month, including a daily attendance breakdown."
+            },
+            "requests": {
+                "title": "User Request History",
+                "description": "All leave and work requests submitted by this user, with their current status."
+            }
+        },
+        "adminHolidays": {
+            "yearNav": {
+                "title": "Year Navigation",
+                "description": "Switch between years to view, add, or remove holidays for any year."
+            },
+            "importBtn": {
+                "title": "Import Public Holidays",
+                "description": "Automatically populate Slovenian public holidays for the current and next year with a single click."
+            },
+            "addBtn": {
+                "title": "Add Holiday",
+                "description": "Manually create a new holiday entry with a date, name, description, and optional annual recurrence."
+            },
+            "table": {
+                "title": "Holiday List",
+                "description": "All holidays for the selected year. Click the edit or delete icons to modify entries."
+            }
+        },
+        "adminPendingRequests": {
+            "table": {
+                "title": "Pending Requests",
+                "description": "All requests awaiting your decision. Use the column header filters to narrow down by user, type, or date. Click Approve or Reject on any row to process it."
+            }
+        },
+        "adminRequestHistory": {
+            "table": {
+                "title": "Request History",
+                "description": "All processed requests — approved, rejected, and cancelled. Use the column filters to search. Approved requests can still be cancelled if needed."
+            }
+        },
+        "adminDev": {
+            "testEmail": {
+                "title": "Test Email Notifications",
+                "description": "Send a test email to any address to verify that the email notification pipeline is working correctly."
+            },
+            "testPush": {
+                "title": "Test Push Notification",
+                "description": "Send a test push notification to a specific user by their ID to verify their subscription is active."
+            },
+            "testAdminPush": {
+                "title": "Test Admin Push",
+                "description": "Broadcast a test push notification to all admin users at once."
+            },
+            "simulateFlow": {
+                "title": "Simulate User Flow",
+                "description": "Run a full request-approval flow for a user by email — useful for end-to-end testing of the notification pipeline."
+            },
+            "subscriptions": {
+                "title": "View Subscriptions",
+                "description": "List all active push notification subscriptions registered by admin users, with their device details."
             }
         }
     }

--- a/messages/en.json
+++ b/messages/en.json
@@ -1335,6 +1335,48 @@
                 "title": "Your Requests",
                 "description": "All your submitted requests are listed here with their type, dates, hours, and current status. Double-click any row to view or edit a pending request."
             }
+        },
+        "urnikNetClock": {
+            "clockCard": {
+                "title": "Clock In / Clock Out",
+                "description": "Log your arrival and departure to urnik.net directly from here. The badges show whether you have already clocked in or out today."
+            },
+            "workTime": {
+                "title": "Today's Work Time",
+                "description": "Live figures pulled from urnik.net: total hours worked today, overtime, lunch break, and when your shift ends."
+            },
+            "balance": {
+                "title": "Hour Balance",
+                "description": "Your current day balance, cumulative balance so far this month, and total annual balance as of yesterday."
+            },
+            "vacation": {
+                "title": "Vacation & Leave",
+                "description": "Remaining vacation days from last year, this year's leave entitlement, and your configured daily work time."
+            }
+        },
+        "urnikNetRequests": {
+            "nav": {
+                "title": "Navigate and Create",
+                "description": "Step through months with the arrows to review past or future requests. Use Create Request to submit a new request directly to urnik.net. The badge shows your connection status."
+            },
+            "table": {
+                "title": "Requests Table",
+                "description": "Shows both pending requests (calculated from your approved leave) and requests already submitted to urnik.net, with their status and confirmation details."
+            }
+        },
+        "urnikNetHours": {
+            "nav": {
+                "title": "Navigate Months",
+                "description": "Step through months with the arrows. Your vacation balance and hour balance are shown on the right for a quick overview."
+            },
+            "details": {
+                "title": "Monthly Summary",
+                "description": "Opens a detailed breakdown: billing hours, planned hours, balance, vacation balance, sick leave, work from home days, and more."
+            },
+            "table": {
+                "title": "Daily Hours Table",
+                "description": "Each row is one working day. Columns show clock-in, clock-out, attendance hours, accounted hours, and running day, month, and year balances."
+            }
         }
     }
 }

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -1303,6 +1303,28 @@
                 "title": "Kliknite dan",
                 "description": "Kliknite katero koli celico z zabeleženimi urami za ogled podrobnih časovnih vnosov za ta dan."
             }
+        },
+        "hours": {
+            "summary": {
+                "title": "Povzetek ur",
+                "description": "Hiter pregled skupnih zabeleženih ur, bilance v primerjavi s pričakovanimi in razčlenitev po vrsti ure za tekoči teden in mesec."
+            },
+            "navigation": {
+                "title": "Pomikanje po obdobjih",
+                "description": "Premikajte se med tedni ali meseci s puščicami ter preklapljajte med tedenskim in mesečnim pogledom z gumbi na desni."
+            },
+            "addEntry": {
+                "title": "Dodaj ure",
+                "description": "Ročno zabeležite ure za določeno obdobje. Izberite vrsto ure, datum in število ur."
+            },
+            "table": {
+                "title": "Tabela ur",
+                "description": "Vsaka vrstica je vrsta ure (Delo, Dopust, Bolniška itn.). Vsak stolpec je dan. Zgornja vrstica prikazuje skupne ure na dan za vse vrste."
+            },
+            "editCell": {
+                "title": "Urejanje ur v tabeli",
+                "description": "Kliknite katero koli celico v vrstici ROČNO za neposredno vnašanje ur. Spremembe se zberejo in shranijo skupaj ob kliku na Shrani."
+            }
         }
     }
 }

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -1231,6 +1231,42 @@
                 "title": "Bilanca",
                 "description": "Bilanca primerja skupne zabeležene ure s pričakovanimi delovnimi urami za izbrano obdobje. Zelena pomeni več, oranžna manj."
             }
+        },
+        "tasks": {
+            "newTask": {
+                "title": "Ustvari nalogo",
+                "description": "Kliknite za dodajanje nove naloge. Dodelite jo seznamu, nastavite status in takoj začnite slediti času."
+            },
+            "groups": {
+                "title": "Skupine nalog",
+                "description": "Naloge so razvrščene po seznamih. Tukaj se prikazujejo samo naloge v teku — odprite seznam za ogled vseh statusov."
+            },
+            "timer": {
+                "title": "Sledenje časa",
+                "description": "Pritisnite gumb za predvajanje, da začnete slediti času naloge. Pritisnite stop, ko končate. Hkrati lahko teče samo ena naloga."
+            },
+            "timeEntries": {
+                "title": "Vnosi časa",
+                "description": "Kliknite trajanje za ogled in urejanje posameznih vnosov. Koristno za popravek časa začetka ali konca po dejstvu."
+            }
+        },
+        "tasksList": {
+            "newTask": {
+                "title": "Ustvari nalogo",
+                "description": "Dodajte novo nalogo v ta seznam. Nastavite status, sledite času in ugnezdite podnaloge."
+            },
+            "statusSections": {
+                "title": "Razdelki po statusu",
+                "description": "Naloge so razvrščene po statusu. Kliknite glavo razdelka za razširitev ali skrčitev."
+            },
+            "timer": {
+                "title": "Sledenje časa",
+                "description": "Pritisnite gumb za predvajanje, da začnete slediti času naloge. Pritisnite stop, ko končate. Hkrati lahko teče samo ena naloga."
+            },
+            "actions": {
+                "title": "Dejanja naloge",
+                "description": "Uporabite gumb plus za dodajanje podnaloge ali gumb koš za brisanje naloge."
+            }
         }
     }
 }

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -1267,6 +1267,24 @@
                 "title": "Dejanja naloge",
                 "description": "Uporabite gumb plus za dodajanje podnaloge ali gumb koš za brisanje naloge."
             }
+        },
+        "shifts": {
+            "navigation": {
+                "title": "Pomikanje po obdobjih",
+                "description": "Uporabite puščice za premik naprej ali nazaj po tednih ali mesecih. Kliknite Danes za vrnitev na trenutno obdobje."
+            },
+            "viewToggle": {
+                "title": "Pogled po tednih in mesecih",
+                "description": "Preklapljajte med 7-dnevnim tedenskim pogledom in celomesečnim pogledom. Koledar se takoj posodobi."
+            },
+            "calendar": {
+                "title": "Koledar izmen",
+                "description": "Vsaka vrstica predstavlja člana ekipe, vsak stolpec pa dan. Barvne oznake prikazujejo, kje delajo — pisarna, dom, dopust ali bolniška."
+            },
+            "cell": {
+                "title": "Klikabilne celice",
+                "description": "Kliknite katero koli celico za ogled podrobnosti izmene, ali kliknite prazno delovno celico za oddajo zahtevka, npr. za dopust ali delo od doma."
+            }
         }
     }
 }

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -1213,6 +1213,24 @@
                 "title": "Vnosi časa",
                 "description": "Prikaže vse posamezne vnose časa, zabeležene danes za izbrano nalogo."
             }
+        },
+        "timeSheets": {
+            "table": {
+                "title": "Urnik dela",
+                "description": "Ta stran prikazuje vse naloge, na katerih ste sledili čas, z dnevnimi vsotami za izbrani teden ali mesec."
+            },
+            "taskCell": {
+                "title": "Vnosi časa naloge",
+                "description": "Kliknite trajanje v vrstici naloge za ogled vnosov. Čas začetka in konca lahko popravite — trajanje se takoj posodobi. Koristno, če ste pozabili začeti sledenje ali morate popraviti čas."
+            },
+            "dateCell": {
+                "title": "Klikalnе vsote",
+                "description": "Kliknite katero koli število ur v stolpcu datuma, da vidite vse posamezne vnose časa za tisti dan."
+            },
+            "balance": {
+                "title": "Bilanca",
+                "description": "Bilanca primerja skupne zabeležene ure s pričakovanimi delovnimi urami za izbrano obdobje. Zelena pomeni več, oranžna manj."
+            }
         }
     }
 }

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -1335,6 +1335,48 @@
                 "title": "Vaši zahtevki",
                 "description": "Tu so navedeni vsi oddani zahtevki z vrsto, datumi, urami in trenutnim statusom. Dvokliknite vrstico za ogled ali urejanje čakajočega zahtevka."
             }
+        },
+        "urnikNetClock": {
+            "clockCard": {
+                "title": "Prihod / Odhod",
+                "description": "Zabeležite prihod in odhod na urnik.net neposredno od tu. Oznake prikazujejo, ali ste danes že evidentirali prihod ali odhod."
+            },
+            "workTime": {
+                "title": "Delošni čas danes",
+                "description": "Podatki v živo z urnik.net: skupne ure dela danes, nadure, odmor za malico in kdaj se konča vaša izmena."
+            },
+            "balance": {
+                "title": "Bilanca ur",
+                "description": "Vaša bilanca za tekouči dan, skupna bilanca do zdaj v tem mesecu in letna bilanca do včeraj."
+            },
+            "vacation": {
+                "title": "Dopust in odsotnost",
+                "description": "Preostali dni dopusta iz lanskega leta, letna pravica do dopusta in nastavljeni dnevni delovni čas."
+            }
+        },
+        "urnikNetRequests": {
+            "nav": {
+                "title": "Pomikanje in ustvarjanje",
+                "description": "Premikajte se po mesecih s puščicami za pregled preteklih ali prihodnjih zahtevkov. Gumb Ustvari zahtevek odda novo vlogo neposredno na urnik.net. Oznaka prikazuje status povezave."
+            },
+            "table": {
+                "title": "Tabela zahtevkov",
+                "description": "Prikazuje tako čakajoče zahtevke (izračunane iz odobrenih odsotnosti) kot že oddane zahtevke na urnik.net z njihovim statusom in podrobnostmi potrditve."
+            }
+        },
+        "urnikNetHours": {
+            "nav": {
+                "title": "Pomikanje po mesecih",
+                "description": "Premikajte se med meseci s puščicami. Na desni strani sta prikazana stanje dopusta in bilanca ur za hiter pregled."
+            },
+            "details": {
+                "title": "Mesečni povzetek",
+                "description": "Odpre podrobno razdelitev: obračunske ure, načrtovane ure, bilanca, stanje dopusta, bolniška, dni dela od doma in več."
+            },
+            "table": {
+                "title": "Dnevna tabela ur",
+                "description": "Vsaka vrstica je en delovni dan. Stolpci prikazujejo prihod, odhod, prisotnost, obračunane ure in tečočo bilanco dneva, meseca in leta."
+            }
         }
     }
 }

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -1321,6 +1321,20 @@
                 "title": "Tabela ur",
                 "description": "Vsaka vrstica je vrsta ure (Delo, Dopust, Bolniška itn.). Vsak stolpec je dan. Zgornja vrstica prikazuje skupne ure na dan za vse vrste."
             }
+        },
+        "requests": {
+            "controls": {
+                "title": "Iskanje in ustvarjanje",
+                "description": "Uporabite iskalno polje za filtriranje zahtev po vrsti, datumu ali statusu. Kliknite Nov zahtevek za oddajo nove vloge za odsotnost ali delo."
+            },
+            "newRequest": {
+                "title": "Nov zahtevek",
+                "description": "Odpre obrazec za zahtevek, kjer izberete vrsto (dopust, bolniška, delo od doma itn.), določite datume in po želji dodate razlog."
+            },
+            "table": {
+                "title": "Vaši zahtevki",
+                "description": "Tu so navedeni vsi oddani zahtevki z vrsto, datumi, urami in trenutnim statusom. Dvokliknite vrstico za ogled ali urejanje čakajočega zahtevka."
+            }
         }
     }
 }

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -121,7 +121,8 @@
         "menu": {
             "settings": "Nastavitve",
             "language": "Jezik",
-            "theme": "Tema"
+            "theme": "Tema",
+            "restartTutorial": "Ponovi vodič"
         },
         "notifications": {
             "title": "Obvestila",
@@ -1191,6 +1192,23 @@
         "previous": "Nazaj",
         "done": "Razumem",
         "skip": "Preskoči vodič",
-        "progress": "{{current}} od {{total}}"
+        "tracker": {
+            "hourType": {
+                "title": "Vrsta ure",
+                "description": "Izberite vrsto časa, ki ga beležite — delo, odmor ali zasebno."
+            },
+            "taskSelect": {
+                "title": "Naloga",
+                "description": "Po želji povežite beleženi čas z določeno nalogo v teku."
+            },
+            "timerButton": {
+                "title": "Zaženi / Ustavi štoparico",
+                "description": "Pritisnite za začetek beleženja časa. Znova pritisnite za ustavitev in shranitev vnosa."
+            },
+            "dailySummary": {
+                "title": "Dnevni povzetek",
+                "description": "Pregled sledenih, ročnih in skupnih ur za današnji dan."
+            }
+        }
     }
 }

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -1285,6 +1285,24 @@
                 "title": "Klikabilne celice",
                 "description": "Kliknite katero koli celico za ogled podrobnosti izmene, ali kliknite prazno delovno celico za oddajo zahtevka, npr. za dopust ali delo od doma."
             }
+        },
+        "yearlyCalendar": {
+            "navigation": {
+                "title": "Pomikanje po letih",
+                "description": "Uporabite puščice za premikanje med leti ali izberite leto iz spustnega seznama."
+            },
+            "balance": {
+                "title": "Letna bilanca",
+                "description": "Vaša skupna bilanca ur za izbrano leto. Zelena pomeni, da ste pred pričakovano normo, oranžna pa, da ste za njo."
+            },
+            "calendar": {
+                "title": "Pregled leta",
+                "description": "Vsaka vrstica predstavlja mesec, vsak stolpec pa dan. Barvne oznake prikazujejo zabeležene ure po vrsti. Vikendi so zatemnjen, prazniki so označeni z oranžno."
+            },
+            "cell": {
+                "title": "Kliknite dan",
+                "description": "Kliknite katero koli celico z zabeleženimi urami za ogled podrobnih časovnih vnosov za ta dan."
+            }
         }
     }
 }

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -1320,10 +1320,6 @@
             "table": {
                 "title": "Tabela ur",
                 "description": "Vsaka vrstica je vrsta ure (Delo, Dopust, Bolniška itn.). Vsak stolpec je dan. Zgornja vrstica prikazuje skupne ure na dan za vse vrste."
-            },
-            "editCell": {
-                "title": "Urejanje ur v tabeli",
-                "description": "Kliknite katero koli celico v vrstici ROČNO za neposredno vnašanje ur. Spremembe se zberejo in shranijo skupaj ob kliku na Shrani."
             }
         }
     }

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -1185,5 +1185,12 @@
         "title": "Upravljavec časa",
         "description": "Učinkovito upravljajte svoj čas, naloge in ure",
         "company": "Acme Corporation"
+    },
+    "tutorial": {
+        "next": "Naprej",
+        "previous": "Nazaj",
+        "done": "Razumem",
+        "skip": "Preskoči vodič",
+        "progress": "{{current}} od {{total}}"
     }
 }

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -487,6 +487,7 @@
             "viewRequestHistory": "Preglej zgodovino zahtevkov",
             "recentPendingRequests": "Nedavni čakajoči zahtevki",
             "recentPendingRequestsDesc": "Najnovejši zahtevki, ki čakajo na odobritev",
+            "noPendingRequests": "Ni čakajočih zahtevkov",
             "upcomingHolidaysSection": "Prihajajoči prazniki",
             "upcomingHolidaysSectionDesc": "Naslednji načrtovani prazniki",
             "viewAllPending": "Preglej vse {count} čakajoče zahtevke",
@@ -1376,6 +1377,104 @@
             "table": {
                 "title": "Dnevna tabela ur",
                 "description": "Vsaka vrstica je en delovni dan. Stolpci prikazujejo prihod, odhod, prisotnost, obračunane ure in tečočo bilanco dneva, meseca in leta."
+            }
+        },
+        "adminOverview": {
+            "stats": {
+                "title": "Statistike pregleda",
+                "description": "Na enem mestu: skupno število uporabnikov, čakajoči zahtevki, prihajajoči prazniki in aktivni seznami nalog."
+            },
+            "statusBreakdown": {
+                "title": "Pregled statusov zahtevkov",
+                "description": "Število vseh zahtevkov po statusu: čakajoči, odobreni, zavrnjeni in preklicani."
+            },
+            "quickActions": {
+                "title": "Hitre akcije",
+                "description": "Bližnjice do najpogostejših administratorskih opravil — upravljanje uporabnikov, pregled čakajočih zahtevkov, upravljanje praznikov in ogled zgodovine zahtevkov."
+            },
+            "recentRequests": {
+                "title": "Nedavni čakajoči zahtevki",
+                "description": "Pet najnovejših zahtevkov, ki še čakajo na vašo odločitev."
+            },
+            "upcomingHolidays": {
+                "title": "Prihajajoči prazniki",
+                "description": "Naslednji načrtovani prazniki. Kliknite Prikaži vse za upravljanje celotnega seznama praznikov."
+            }
+        },
+        "adminUsers": {
+            "toolbar": {
+                "title": "Iskanje in ustvarjanje uporabnikov",
+                "description": "Filtrirajte uporabnike po imenu, vklopite prikaz deaktiviranih računov ali odprite meni za ustvarjanje novega uporabnika oz. izvoz seznama."
+            },
+            "table": {
+                "title": "Seznam uporabnikov",
+                "description": "Vsi uporabniki z vlogo in statusom. Dvokliknite vrstico za odpiranje podrobne strani uporabnika."
+            }
+        },
+        "adminUserDetail": {
+            "editForm": {
+                "title": "Uredi profil uporabnika",
+                "description": "Posodobite ime, e-pošto, vlogo, delovni čas in status računa. Spremembe se uveljavijo takoj."
+            },
+            "hours": {
+                "title": "Ure in sledenje uporabnika",
+                "description": "Oglejte si in uredite ročne ter sledene ure uporabnika za tekoči mesec, vključno z dnevno razčlenitvijo prisotnosti."
+            },
+            "requests": {
+                "title": "Zgodovina zahtevkov uporabnika",
+                "description": "Vse vloge za odsotnost in delo, ki jih je oddal ta uporabnik, z njihovim trenutnim statusom."
+            }
+        },
+        "adminHolidays": {
+            "yearNav": {
+                "title": "Pomikanje po letih",
+                "description": "Preklapljajte med leti za ogled, dodajanje ali brisanje praznikov za katerokoli leto."
+            },
+            "importBtn": {
+                "title": "Uvozi državne praznike",
+                "description": "Z enim klikom samodejno dodajte slovenske državne praznike za tekoče in naslednje leto."
+            },
+            "addBtn": {
+                "title": "Dodaj praznik",
+                "description": "Ročno ustvarite nov praznik z datumom, imenom, opisom in možnostjo letnega ponavljanja."
+            },
+            "table": {
+                "title": "Seznam praznikov",
+                "description": "Vsi prazniki za izbrano leto. Kliknite ikono za urejanje ali brisanje."
+            }
+        },
+        "adminPendingRequests": {
+            "table": {
+                "title": "Čakajoči zahtevki",
+                "description": "Vsi zahtevki, ki čakajo na vašo odločitev. Uporabite filtre v glavi stolpcev za zožitev po uporabniku, vrsti ali datumu. Kliknite Odobri ali Zavrni za obdelavo."
+            }
+        },
+        "adminRequestHistory": {
+            "table": {
+                "title": "Zgodovina zahtevkov",
+                "description": "Vsi obdelani zahtevki — odobreni, zavrnjeni in preklicani. Uporabite filtre za iskanje. Odobrene zahtevke je še vedno mogoče preklicati."
+            }
+        },
+        "adminDev": {
+            "testEmail": {
+                "title": "Test e-poštnih obvestil",
+                "description": "Pošljite testno e-pošto na katerikoli naslov za preveritev, ali cevovod e-poštnih obvestil deluje pravilno."
+            },
+            "testPush": {
+                "title": "Test potisnih obvestil",
+                "description": "Pošljite testno potisno obvestilo določenemu uporabniku po ID-ju za preveritev aktivnosti naročnine."
+            },
+            "testAdminPush": {
+                "title": "Test admin potisnih obvestil",
+                "description": "Oddajte testno potisno obvestilo vsem administratorskim uporabnikom hkrati."
+            },
+            "simulateFlow": {
+                "title": "Simuliraj potek",
+                "description": "Zaženite celoten potek oddaje in odobritve zahtevka za uporabnika po e-pošti — koristno za celovito testiranje cevovoda obvestil."
+            },
+            "subscriptions": {
+                "title": "Ogled naročnin",
+                "description": "Seznam vseh aktivnih naročnin na potisna obvestila, ki so jih registrirali administratorski uporabniki, z informacijami o napravah."
             }
         }
     }

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -1208,6 +1208,10 @@
             "dailySummary": {
                 "title": "Dnevni povzetek",
                 "description": "Pregled sledenih, ročnih in skupnih ur za današnji dan."
+            },
+            "timeEntries": {
+                "title": "Vnosi časa",
+                "description": "Prikaže vse posamezne vnose časa, zabeležene danes za izbrano nalogo."
             }
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
                 "clsx": "^2.1.1",
                 "cmdk": "^1.1.1",
                 "date-fns-tz": "^3.2.0",
+                "driver.js": "^1.4.0",
                 "exceljs": "^4.4.0",
                 "lucide-react": "^0.555.0",
                 "next": "^16.0.7",
@@ -5821,6 +5822,12 @@
             "funding": {
                 "url": "https://dotenvx.com"
             }
+        },
+        "node_modules/driver.js": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/driver.js/-/driver.js-1.4.0.tgz",
+            "integrity": "sha512-Gm64jm6PmcU+si21sQhBrTAM1JvUrR0QhNmjkprNLxohOBzul9+pNHXgQaT9lW84gwg9GMLB3NZGuGolsz5uew==",
+            "license": "MIT"
         },
         "node_modules/dunder-proto": {
             "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "date-fns-tz": "^3.2.0",
+        "driver.js": "^1.4.0",
         "exceljs": "^4.4.0",
         "lucide-react": "^0.555.0",
         "next": "^16.0.7",

--- a/src/app/(protected)/admin/components/quick-actions.tsx
+++ b/src/app/(protected)/admin/components/quick-actions.tsx
@@ -17,7 +17,7 @@ interface QuickActionsProps {
 
 export function QuickActions({ translations }: QuickActionsProps) {
     return (
-        <Card>
+        <Card id="admin-quick-actions">
             <CardHeader>
                 <CardTitle>{translations.title}</CardTitle>
                 <CardDescription>{translations.description}</CardDescription>

--- a/src/app/(protected)/admin/components/recent-pending-requests.tsx
+++ b/src/app/(protected)/admin/components/recent-pending-requests.tsx
@@ -14,6 +14,7 @@ interface RecentPendingRequestsProps {
         title: string
         description: string
         viewAll: (params: { count: number }) => string
+        noPending: string
         user: string
         type: string
         period: string
@@ -27,13 +28,23 @@ export function RecentPendingRequests({
     translations,
 }: RecentPendingRequestsProps) {
     if (requests.length === 0) {
-        return null
+        return (
+            <Card id="admin-recent-requests">
+                <CardHeader>
+                    <CardTitle>{translations.title}</CardTitle>
+                    <CardDescription>{translations.description}</CardDescription>
+                </CardHeader>
+                <CardContent>
+                    <p className="text-sm text-muted-foreground">{translations.noPending}</p>
+                </CardContent>
+            </Card>
+        )
     }
 
     const displayedRequests = requests.slice(0, 5)
 
     return (
-        <Card>
+        <Card id="admin-recent-requests">
             <CardHeader>
                 <CardTitle>{translations.title}</CardTitle>
                 <CardDescription>{translations.description}</CardDescription>

--- a/src/app/(protected)/admin/components/request-status-breakdown.tsx
+++ b/src/app/(protected)/admin/components/request-status-breakdown.tsx
@@ -23,7 +23,7 @@ export function RequestStatusBreakdown({
     translations,
 }: RequestStatusBreakdownProps) {
     return (
-        <Card>
+        <Card id="admin-status-breakdown">
             <CardHeader>
                 <CardTitle>{translations.title}</CardTitle>
                 <CardDescription>{translations.description}</CardDescription>

--- a/src/app/(protected)/admin/components/stats-cards.tsx
+++ b/src/app/(protected)/admin/components/stats-cards.tsx
@@ -19,7 +19,7 @@ interface StatsCardsProps {
 
 export function StatsCards({ stats, translations }: StatsCardsProps) {
     return (
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <div id="admin-stats" className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
             {STAT_CONFIGS.map(({ key, icon: Icon, color, href }) => (
                 <Link key={key} href={href}>
                     <Card className="hover:bg-accent transition-colors cursor-pointer">

--- a/src/app/(protected)/admin/components/upcoming-holidays.tsx
+++ b/src/app/(protected)/admin/components/upcoming-holidays.tsx
@@ -22,7 +22,7 @@ export function UpcomingHolidays({ holidays, locale, translations }: UpcomingHol
     const displayedHolidays = holidays.slice(0, 5)
 
     return (
-        <Card>
+        <Card id="admin-upcoming-holidays">
             <CardHeader>
                 <CardTitle>{translations.title}</CardTitle>
                 <CardDescription>{translations.description}</CardDescription>

--- a/src/app/(protected)/admin/dev/components/dev-tools-client.tsx
+++ b/src/app/(protected)/admin/dev/components/dev-tools-client.tsx
@@ -80,7 +80,7 @@ export function DevToolsClient({ translations: t }: DevToolsClientProps) {
 
     return (
         <div className="space-y-4">
-            <Card>
+            <Card id="dev-test-email">
                 <CardHeader>
                     <CardTitle className="flex items-center gap-2">
                         <Mail className="h-5 w-5" />
@@ -108,7 +108,7 @@ export function DevToolsClient({ translations: t }: DevToolsClientProps) {
                 </CardContent>
             </Card>
 
-            <Card>
+            <Card id="dev-test-push">
                 <CardHeader>
                     <CardTitle className="flex items-center gap-2">
                         <Bell className="h-5 w-5" />
@@ -135,7 +135,7 @@ export function DevToolsClient({ translations: t }: DevToolsClientProps) {
                 </CardContent>
             </Card>
 
-            <Card>
+            <Card id="dev-test-admin-push">
                 <CardHeader>
                     <CardTitle className="flex items-center gap-2">
                         <Users className="h-5 w-5" />
@@ -152,7 +152,7 @@ export function DevToolsClient({ translations: t }: DevToolsClientProps) {
                 </CardContent>
             </Card>
 
-            <Card>
+            <Card id="dev-simulate-flow">
                 <CardHeader>
                     <CardTitle className="flex items-center gap-2">
                         <Workflow className="h-5 w-5" />
@@ -180,7 +180,7 @@ export function DevToolsClient({ translations: t }: DevToolsClientProps) {
                 </CardContent>
             </Card>
 
-            <Card>
+            <Card id="dev-subscriptions">
                 <CardHeader>
                     <CardTitle className="flex items-center gap-2">
                         <List className="h-5 w-5" />

--- a/src/app/(protected)/admin/dev/page.tsx
+++ b/src/app/(protected)/admin/dev/page.tsx
@@ -1,8 +1,14 @@
 import { getTranslations } from "next-intl/server"
 import { DevToolsClient } from "./components/dev-tools-client"
+import { getTutorialsSeen, PageTour } from "@/features/tutorial"
 
 export default async function DevToolsPage() {
     const tTestEmail = await getTranslations("admin.dev.testEmail")
+    const [tutorialsSeen, tTutorial, tAdminDev] = await Promise.all([
+        getTutorialsSeen(),
+        getTranslations("tutorial"),
+        getTranslations("tutorial.adminDev"),
+    ])
     const tTestPush = await getTranslations("admin.dev.testPush")
     const tTestAdminPush = await getTranslations("admin.dev.testAdminPush")
     const tSimulateFlow = await getTranslations("admin.dev.simulateFlow")
@@ -12,51 +18,92 @@ export default async function DevToolsPage() {
     const tCommon = await getTranslations("common.status")
 
     return (
-        <DevToolsClient
-            translations={{
-                testEmail: {
-                    title: tTestEmail("title"),
-                    description: tTestEmail("description"),
-                    recipientLabel: tTestEmail("recipientLabel"),
-                    recipientPlaceholder: tTestEmail("recipientPlaceholder"),
-                    button: tTestEmail("button"),
-                },
-                testPush: {
-                    title: tTestPush("title"),
-                    description: tTestPush("description"),
-                    userIdLabel: tTestPush("userIdLabel"),
-                    userIdPlaceholder: tTestPush("userIdPlaceholder"),
-                    button: tTestPush("button"),
-                },
-                testAdminPush: {
-                    title: tTestAdminPush("title"),
-                    description: tTestAdminPush("description"),
-                    button: tTestAdminPush("button"),
-                },
-                simulateFlow: {
-                    title: tSimulateFlow("title"),
-                    description: tSimulateFlow("description"),
-                    userEmailLabel: tSimulateFlow("userEmailLabel"),
-                    userEmailPlaceholder: tSimulateFlow("userEmailPlaceholder"),
-                    button: tSimulateFlow("button"),
-                },
-                subscriptions: {
-                    title: tSubscriptions("title"),
-                    description: tSubscriptions("description"),
-                    button: tSubscriptions("button"),
-                    subscriptionText: tSubscriptions("subscriptionText"),
-                    table: {
-                        user: tSubscriptionsTable("user"),
-                        email: tSubscriptionsTable("email"),
-                        role: tSubscriptionsTable("role"),
-                        created: tSubscriptionsTable("created"),
+        <>
+            <PageTour
+                pageKey="/admin/dev"
+                seenPages={tutorialsSeen}
+                nextLabel={tTutorial("next")}
+                prevLabel={tTutorial("previous")}
+                doneLabel={tTutorial("done")}
+                steps={[
+                    {
+                        element: "#dev-test-email",
+                        title: tAdminDev("testEmail.title"),
+                        description: tAdminDev("testEmail.description"),
+                        side: "bottom",
                     },
-                },
-                results: {
-                    admins: tResults("admins"),
-                },
-                loading: tCommon("loading"),
-            }}
-        />
+                    {
+                        element: "#dev-test-push",
+                        title: tAdminDev("testPush.title"),
+                        description: tAdminDev("testPush.description"),
+                        side: "bottom",
+                    },
+                    {
+                        element: "#dev-test-admin-push",
+                        title: tAdminDev("testAdminPush.title"),
+                        description: tAdminDev("testAdminPush.description"),
+                        side: "bottom",
+                    },
+                    {
+                        element: "#dev-simulate-flow",
+                        title: tAdminDev("simulateFlow.title"),
+                        description: tAdminDev("simulateFlow.description"),
+                        side: "bottom",
+                    },
+                    {
+                        element: "#dev-subscriptions",
+                        title: tAdminDev("subscriptions.title"),
+                        description: tAdminDev("subscriptions.description"),
+                        side: "bottom",
+                    },
+                ]}
+            />
+            <DevToolsClient
+                translations={{
+                    testEmail: {
+                        title: tTestEmail("title"),
+                        description: tTestEmail("description"),
+                        recipientLabel: tTestEmail("recipientLabel"),
+                        recipientPlaceholder: tTestEmail("recipientPlaceholder"),
+                        button: tTestEmail("button"),
+                    },
+                    testPush: {
+                        title: tTestPush("title"),
+                        description: tTestPush("description"),
+                        userIdLabel: tTestPush("userIdLabel"),
+                        userIdPlaceholder: tTestPush("userIdPlaceholder"),
+                        button: tTestPush("button"),
+                    },
+                    testAdminPush: {
+                        title: tTestAdminPush("title"),
+                        description: tTestAdminPush("description"),
+                        button: tTestAdminPush("button"),
+                    },
+                    simulateFlow: {
+                        title: tSimulateFlow("title"),
+                        description: tSimulateFlow("description"),
+                        userEmailLabel: tSimulateFlow("userEmailLabel"),
+                        userEmailPlaceholder: tSimulateFlow("userEmailPlaceholder"),
+                        button: tSimulateFlow("button"),
+                    },
+                    subscriptions: {
+                        title: tSubscriptions("title"),
+                        description: tSubscriptions("description"),
+                        button: tSubscriptions("button"),
+                        subscriptionText: tSubscriptions("subscriptionText"),
+                        table: {
+                            user: tSubscriptionsTable("user"),
+                            email: tSubscriptionsTable("email"),
+                            role: tSubscriptionsTable("role"),
+                            created: tSubscriptionsTable("created"),
+                        },
+                    },
+                    results: {
+                        admins: tResults("admins"),
+                    },
+                    loading: tCommon("loading"),
+                }}
+            />
+        </>
     )
 }

--- a/src/app/(protected)/admin/holidays/components/holidays-table.tsx
+++ b/src/app/(protected)/admin/holidays/components/holidays-table.tsx
@@ -230,7 +230,7 @@ export function HolidaysTable({ holidays, translations }: HolidaysTableProps) {
     return (
         <div className="flex flex-col gap-4 h-full">
             <div className="flex items-center justify-between">
-                <div className="flex items-center gap-2">
+                <div id="holidays-year-nav" className="flex items-center gap-2">
                     <Button
                         variant="outline"
                         size="icon"
@@ -251,6 +251,7 @@ export function HolidaysTable({ holidays, translations }: HolidaysTableProps) {
                 </div>
                 <div className="flex gap-2">
                     <Button
+                        id="holidays-import-btn"
                         variant="secondary"
                         onClick={() => generateMutation.mutate()}
                         disabled={generateMutation.isPending}
@@ -262,7 +263,7 @@ export function HolidaysTable({ holidays, translations }: HolidaysTableProps) {
                     </Button>
                     <Dialog open={isDialogOpen} onOpenChange={handleOpenChange}>
                         <DialogTrigger asChild>
-                            <Button>
+                            <Button id="holidays-add-btn">
                                 <Plus className="h-4 w-4 mr-2" />
                                 {translations.form.addHoliday}
                             </Button>
@@ -357,7 +358,7 @@ export function HolidaysTable({ holidays, translations }: HolidaysTableProps) {
                     </Dialog>
                 </div>
             </div>
-            <div className="rounded-md border overflow-auto flex-1 min-h-0">
+            <div id="holidays-table" className="rounded-md border overflow-auto flex-1 min-h-0">
                 <Table>
                     <TableHeader className="sticky top-0 z-10 bg-background">
                         <TableRow>

--- a/src/app/(protected)/admin/holidays/page.tsx
+++ b/src/app/(protected)/admin/holidays/page.tsx
@@ -1,6 +1,7 @@
 import { getTranslations } from "next-intl/server"
 import { getHolidays } from "./actions/holiday-actions"
 import { HolidaysTable } from "./components/holidays-table"
+import { getTutorialsSeen, PageTour } from "@/features/tutorial"
 
 export const dynamic = "force-dynamic"
 
@@ -43,9 +44,50 @@ export default async function HolidaysPage() {
         },
     }
 
+    const [tutorialsSeen, tTutorial, tAdminHolidays] = await Promise.all([
+        getTutorialsSeen(),
+        getTranslations("tutorial"),
+        getTranslations("tutorial.adminHolidays"),
+    ])
+
     return (
-        <div className="flex flex-col gap-4 min-w-0 h-full">
-            <HolidaysTable holidays={holidays} translations={translations} />
-        </div>
+        <>
+            <PageTour
+                pageKey="/admin/holidays"
+                seenPages={tutorialsSeen}
+                nextLabel={tTutorial("next")}
+                prevLabel={tTutorial("previous")}
+                doneLabel={tTutorial("done")}
+                steps={[
+                    {
+                        element: "#holidays-year-nav",
+                        title: tAdminHolidays("yearNav.title"),
+                        description: tAdminHolidays("yearNav.description"),
+                        side: "bottom",
+                    },
+                    {
+                        element: "#holidays-import-btn",
+                        title: tAdminHolidays("importBtn.title"),
+                        description: tAdminHolidays("importBtn.description"),
+                        side: "bottom",
+                    },
+                    {
+                        element: "#holidays-add-btn",
+                        title: tAdminHolidays("addBtn.title"),
+                        description: tAdminHolidays("addBtn.description"),
+                        side: "bottom",
+                    },
+                    {
+                        element: "#holidays-table",
+                        title: tAdminHolidays("table.title"),
+                        description: tAdminHolidays("table.description"),
+                        side: "top",
+                    },
+                ]}
+            />
+            <div className="flex flex-col gap-4 min-w-0 h-full">
+                <HolidaysTable holidays={holidays} translations={translations} />
+            </div>
+        </>
     )
 }

--- a/src/app/(protected)/admin/page.tsx
+++ b/src/app/(protected)/admin/page.tsx
@@ -13,6 +13,7 @@ import { RecentPendingRequests } from "./components/recent-pending-requests"
 import { UpcomingHolidays } from "./components/upcoming-holidays"
 import { getUpcomingHolidays } from "./utils"
 import type { Request } from "./schemas"
+import { getTutorialsSeen, PageTour } from "@/features/tutorial"
 
 export default async function AdminOverviewPage() {
     const session = await getServerSession(authConfig)
@@ -25,12 +26,24 @@ export default async function AdminOverviewPage() {
     const tAdmin = await getTranslations("admin.overview")
     const tRequests = await getTranslations("requests.statuses")
 
-    const [users, pendingRequests, allRequests, holidaysResult, taskLists] = await Promise.all([
+    const [
+        users,
+        pendingRequests,
+        allRequests,
+        holidaysResult,
+        taskLists,
+        tutorialsSeen,
+        tTutorial,
+        tAdminOverview,
+    ] = await Promise.all([
         getUsers(),
         getAllRequests(["PENDING"]),
         getAllRequests(),
         getHolidays(),
         prisma.list.count(),
+        getTutorialsSeen(),
+        getTranslations("tutorial"),
+        getTranslations("tutorial.adminOverview"),
     ])
 
     const holidays = (holidaysResult.success ? holidaysResult.data : []) ?? []
@@ -108,6 +121,7 @@ export default async function AdminOverviewPage() {
         title: tAdmin("recentPendingRequests"),
         description: tAdmin("recentPendingRequestsDesc"),
         viewAll: (params: { count: number }) => tAdmin("viewAllPending", params),
+        noPending: tAdmin("noPendingRequests"),
         user: tAdmin("user"),
         type: tAdmin("type"),
         period: tAdmin("period"),
@@ -120,29 +134,70 @@ export default async function AdminOverviewPage() {
     }
 
     return (
-        <div className="flex flex-col gap-4">
-            <StatsCards stats={stats} translations={statsTranslations} />
+        <>
+            <PageTour
+                pageKey="/admin"
+                seenPages={tutorialsSeen}
+                nextLabel={tTutorial("next")}
+                prevLabel={tTutorial("previous")}
+                doneLabel={tTutorial("done")}
+                steps={[
+                    {
+                        element: "#admin-stats",
+                        title: tAdminOverview("stats.title"),
+                        description: tAdminOverview("stats.description"),
+                        side: "bottom",
+                    },
+                    {
+                        element: "#admin-status-breakdown",
+                        title: tAdminOverview("statusBreakdown.title"),
+                        description: tAdminOverview("statusBreakdown.description"),
+                        side: "bottom",
+                    },
+                    {
+                        element: "#admin-quick-actions",
+                        title: tAdminOverview("quickActions.title"),
+                        description: tAdminOverview("quickActions.description"),
+                        side: "bottom",
+                    },
+                    {
+                        element: "#admin-recent-requests",
+                        title: tAdminOverview("recentRequests.title"),
+                        description: tAdminOverview("recentRequests.description"),
+                        side: "bottom",
+                    },
+                    {
+                        element: "#admin-upcoming-holidays",
+                        title: tAdminOverview("upcomingHolidays.title"),
+                        description: tAdminOverview("upcomingHolidays.description"),
+                        side: "bottom",
+                    },
+                ]}
+            />
+            <div className="flex flex-col gap-4">
+                <StatsCards stats={stats} translations={statsTranslations} />
 
-            <div className="grid gap-4 md:grid-cols-2">
-                <RequestStatusBreakdown
-                    statusCounts={statusCounts}
-                    translations={statusTranslations}
+                <div className="grid gap-4 md:grid-cols-2">
+                    <RequestStatusBreakdown
+                        statusCounts={statusCounts}
+                        translations={statusTranslations}
+                    />
+                    <QuickActions translations={quickActionsTranslations} />
+                </div>
+
+                <RecentPendingRequests
+                    requests={recentPendingRequests}
+                    locale={locale}
+                    totalPending={pendingRequests.length}
+                    translations={recentRequestsTranslations}
                 />
-                <QuickActions translations={quickActionsTranslations} />
+
+                <UpcomingHolidays
+                    holidays={upcomingHolidays}
+                    locale={locale}
+                    translations={holidaysTranslations}
+                />
             </div>
-
-            <RecentPendingRequests
-                requests={recentPendingRequests}
-                locale={locale}
-                totalPending={pendingRequests.length}
-                translations={recentRequestsTranslations}
-            />
-
-            <UpcomingHolidays
-                holidays={upcomingHolidays}
-                locale={locale}
-                translations={holidaysTranslations}
-            />
-        </div>
+        </>
     )
 }

--- a/src/app/(protected)/admin/pending-requests/components/pending-requests-table.tsx
+++ b/src/app/(protected)/admin/pending-requests/components/pending-requests-table.tsx
@@ -187,7 +187,7 @@ export function PendingRequestsTable({
     return (
         <>
             <div className="flex flex-col gap-4 h-full min-w-0">
-                <div className="rounded-md border flex-1 min-h-0">
+                <div id="pending-table" className="rounded-md border flex-1 min-h-0">
                     <Table>
                         <TableHeader className="sticky top-0 z-30 bg-background">
                             {table.getHeaderGroups().map((headerGroup) => (

--- a/src/app/(protected)/admin/pending-requests/page.tsx
+++ b/src/app/(protected)/admin/pending-requests/page.tsx
@@ -6,6 +6,7 @@ import { getAllRequests } from "../../requests/actions/request-actions"
 import { getHolidays } from "../holidays/actions/holiday-actions"
 import { PendingRequestsTable } from "./components/pending-requests-table"
 import { syncRequestStatuses } from "../../requests/actions/sync-request-statuses"
+import { getTutorialsSeen, PageTour } from "@/features/tutorial"
 
 export default async function PendingRequestsPage() {
     const session = await getServerSession(authConfig)
@@ -73,9 +74,12 @@ export default async function PendingRequestsPage() {
         },
     }
 
-    const [requests, holidaysResult] = await Promise.all([
+    const [requests, holidaysResult, tutorialsSeen, tTutorial, tAdminPending] = await Promise.all([
         getAllRequests(["PENDING"]),
         getHolidays(),
+        getTutorialsSeen(),
+        getTranslations("tutorial"),
+        getTranslations("tutorial.adminPendingRequests"),
     ])
 
     const requestsData = requests.map((r) => ({
@@ -86,15 +90,32 @@ export default async function PendingRequestsPage() {
     const holidays = (holidaysResult.success ? holidaysResult.data : []) ?? []
 
     return (
-        <div className="flex flex-col gap-4 h-full">
-            <div className="flex-1 min-h-0">
-                <PendingRequestsTable
-                    requests={requestsData}
-                    holidays={holidays}
-                    translations={translations}
-                    locale={locale}
-                />
+        <>
+            <PageTour
+                pageKey="/admin/pending-requests"
+                seenPages={tutorialsSeen}
+                nextLabel={tTutorial("next")}
+                prevLabel={tTutorial("previous")}
+                doneLabel={tTutorial("done")}
+                steps={[
+                    {
+                        element: "#pending-table",
+                        title: tAdminPending("table.title"),
+                        description: tAdminPending("table.description"),
+                        side: "top",
+                    },
+                ]}
+            />
+            <div className="flex flex-col gap-4 h-full">
+                <div className="flex-1 min-h-0">
+                    <PendingRequestsTable
+                        requests={requestsData}
+                        holidays={holidays}
+                        translations={translations}
+                        locale={locale}
+                    />
+                </div>
             </div>
-        </div>
+        </>
     )
 }

--- a/src/app/(protected)/admin/request-history/components/request-history-table.tsx
+++ b/src/app/(protected)/admin/request-history/components/request-history-table.tsx
@@ -143,7 +143,7 @@ export function RequestHistoryTable({
     return (
         <>
             <div className="flex flex-col gap-4 h-full min-w-0">
-                <div className="rounded-md border flex-1 min-h-0">
+                <div id="history-table" className="rounded-md border flex-1 min-h-0">
                     <Table>
                         <TableHeader className="sticky top-0 z-30 bg-background">
                             {table.getHeaderGroups().map((headerGroup) => (

--- a/src/app/(protected)/admin/request-history/page.tsx
+++ b/src/app/(protected)/admin/request-history/page.tsx
@@ -5,6 +5,7 @@ import { authConfig } from "@/lib/auth"
 import { getAllRequests } from "../../requests/actions/request-actions"
 import { getHolidays } from "../holidays/actions/holiday-actions"
 import { RequestHistoryTable } from "./components/request-history-table"
+import { getTutorialsSeen, PageTour } from "@/features/tutorial"
 
 export default async function RequestHistoryPage() {
     const session = await getServerSession(authConfig)
@@ -76,10 +77,14 @@ export default async function RequestHistoryPage() {
         },
     }
 
-    const [historyRequests, holidaysResult] = await Promise.all([
-        getAllRequests(["APPROVED", "REJECTED", "CANCELLED"]),
-        getHolidays(),
-    ])
+    const [historyRequests, holidaysResult, tutorialsSeen, tTutorial, tAdminHistory] =
+        await Promise.all([
+            getAllRequests(["APPROVED", "REJECTED", "CANCELLED"]),
+            getHolidays(),
+            getTutorialsSeen(),
+            getTranslations("tutorial"),
+            getTranslations("tutorial.adminRequestHistory"),
+        ])
 
     const historyData = historyRequests.map((r) => ({
         ...r,
@@ -89,15 +94,32 @@ export default async function RequestHistoryPage() {
     const holidays = (holidaysResult.success ? holidaysResult.data : []) ?? []
 
     return (
-        <div className="flex flex-col gap-4 h-full">
-            <div className="flex-1 min-h-0">
-                <RequestHistoryTable
-                    requests={historyData}
-                    holidays={holidays}
-                    translations={translations}
-                    locale={locale}
-                />
+        <>
+            <PageTour
+                pageKey="/admin/request-history"
+                seenPages={tutorialsSeen}
+                nextLabel={tTutorial("next")}
+                prevLabel={tTutorial("previous")}
+                doneLabel={tTutorial("done")}
+                steps={[
+                    {
+                        element: "#history-table",
+                        title: tAdminHistory("table.title"),
+                        description: tAdminHistory("table.description"),
+                        side: "top",
+                    },
+                ]}
+            />
+            <div className="flex flex-col gap-4 h-full">
+                <div className="flex-1 min-h-0">
+                    <RequestHistoryTable
+                        requests={historyData}
+                        holidays={holidays}
+                        translations={translations}
+                        locale={locale}
+                    />
+                </div>
             </div>
-        </div>
+        </>
     )
 }

--- a/src/app/(protected)/admin/users/[id]/page.tsx
+++ b/src/app/(protected)/admin/users/[id]/page.tsx
@@ -13,6 +13,7 @@ import { getHolidaysInRange } from "../../holidays/actions/holiday-actions"
 import { getUserRequestsForAdmin } from "@/app/(protected)/requests/actions/request-actions"
 import { RequestsTable } from "@/app/(protected)/requests/components/requests-table"
 import { UserHoursSection } from "./components/user-hours-section"
+import { getTutorialsSeen, PageTour } from "@/features/tutorial"
 
 function getCurrentMonthDates() {
     const now = new Date()
@@ -40,43 +41,93 @@ export default async function EditUserPage({ params }: { params: Promise<{ id: s
     const { startDate, endDate } = getCurrentMonthDates()
     const session = await getServerSession(authConfig)
 
-    const [user, userHours, userRequests, holidays, attendanceData] = await Promise.all([
+    const [
+        user,
+        userHours,
+        userRequests,
+        holidays,
+        attendanceData,
+        tutorialsSeen,
+        tTutorial,
+        tAdminUserDetail,
+    ] = await Promise.all([
         getUserById(id),
         getHourEntriesForUser(id, startDate, endDate),
         getUserRequestsForAdmin(id),
         getHolidaysInRange(startDate, endDate),
         getAttendanceDataForUser(id, startDate, endDate),
+        getTutorialsSeen(),
+        getTranslations("tutorial"),
+        getTranslations("tutorial.adminUserDetail"),
     ])
 
     return (
-        <div className="flex flex-col gap-6">
-            <Card>
-                <CardContent>
-                    <EditUserForm user={user} currentUserIsDemo={session?.user?.isDemo || false} />
-                </CardContent>
-            </Card>
-
-            <Separator />
-
-            <UserHoursSection
-                userId={id}
-                user={user}
-                initialEntries={userHours}
-                initialHolidays={holidays}
-                initialAttendanceData={attendanceData}
+        <>
+            <PageTour
+                pageKey="/admin/users/detail"
+                seenPages={tutorialsSeen}
+                nextLabel={tTutorial("next")}
+                prevLabel={tTutorial("previous")}
+                doneLabel={tTutorial("done")}
+                steps={[
+                    {
+                        element: "#user-edit-form",
+                        title: tAdminUserDetail("editForm.title"),
+                        description: tAdminUserDetail("editForm.description"),
+                        side: "bottom",
+                    },
+                    {
+                        element: "#user-hours",
+                        title: tAdminUserDetail("hours.title"),
+                        description: tAdminUserDetail("hours.description"),
+                        side: "bottom",
+                    },
+                    {
+                        element: "#user-requests",
+                        title: tAdminUserDetail("requests.title"),
+                        description: tAdminUserDetail("requests.description"),
+                        side: "bottom",
+                    },
+                ]}
             />
+            <div className="flex flex-col gap-6">
+                <Card id="user-edit-form">
+                    <CardContent>
+                        <EditUserForm
+                            user={user}
+                            currentUserIsDemo={session?.user?.isDemo || false}
+                        />
+                    </CardContent>
+                </Card>
 
-            <Separator />
+                <Separator />
 
-            <Card>
-                <CardHeader>
-                    <CardTitle>{t("requests")}</CardTitle>
-                    <CardDescription>{t("requestsDescription")}</CardDescription>
-                </CardHeader>
-                <CardContent>
-                    <RequestsTable requests={userRequests} showUser={false} showNewButton={false} />
-                </CardContent>
-            </Card>
-        </div>
+                <div id="user-hours">
+                    <UserHoursSection
+                        userId={id}
+                        user={user}
+                        initialEntries={userHours}
+                        initialHolidays={holidays}
+                        initialAttendanceData={attendanceData}
+                    />
+                </div>
+
+                <Separator />
+
+                <Card id="user-requests">
+                    <CardHeader>
+                        <CardTitle>{t("requests")}</CardTitle>
+                        <CardDescription>{t("requestsDescription")}</CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                        <RequestsTable
+                            requests={userRequests}
+                            showUser={false}
+                            showNewButton={false}
+                        />
+                    </CardContent>
+                </Card>
+            </div>
+        </>
     )
 }

--- a/src/app/(protected)/admin/users/components/users-table.tsx
+++ b/src/app/(protected)/admin/users/components/users-table.tsx
@@ -121,7 +121,7 @@ export function UsersTableWrapper({ users, currentUserId }: UsersTableProps) {
 
     return (
         <>
-            <div className="flex items-center justify-between gap-4">
+            <div id="users-toolbar" className="flex items-center justify-between gap-4">
                 <div className="flex items-center gap-4 flex-1">
                     <div className="relative max-w-sm flex-1">
                         <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
@@ -167,7 +167,7 @@ export function UsersTableWrapper({ users, currentUserId }: UsersTableProps) {
                     </DropdownMenuContent>
                 </DropdownMenu>
             </div>
-            <div className="rounded-md border overflow-auto flex-1 min-h-0">
+            <div id="users-table" className="rounded-md border overflow-auto flex-1 min-h-0">
                 <Table>
                     <TableHeader className="sticky top-0 z-30 bg-background">
                         <TableRow>

--- a/src/app/(protected)/admin/users/page.tsx
+++ b/src/app/(protected)/admin/users/page.tsx
@@ -2,14 +2,44 @@ import { getServerSession } from "next-auth"
 import { authConfig } from "@/lib/auth"
 import { UsersTableWrapper } from "./components/users-table"
 import { getUsers } from "./actions/user-actions"
+import { getTranslations } from "next-intl/server"
+import { getTutorialsSeen, PageTour } from "@/features/tutorial"
 
 export default async function AdminUsersPage() {
     const session = await getServerSession(authConfig)
-    const users = await getUsers(true)
+    const [users, tutorialsSeen, tTutorial, tAdminUsers] = await Promise.all([
+        getUsers(true),
+        getTutorialsSeen(),
+        getTranslations("tutorial"),
+        getTranslations("tutorial.adminUsers"),
+    ])
 
     return (
-        <div className="flex flex-col gap-4 min-w-0 h-full">
-            <UsersTableWrapper users={users} currentUserId={session!.user.id} />
-        </div>
+        <>
+            <PageTour
+                pageKey="/admin/users"
+                seenPages={tutorialsSeen}
+                nextLabel={tTutorial("next")}
+                prevLabel={tTutorial("previous")}
+                doneLabel={tTutorial("done")}
+                steps={[
+                    {
+                        element: "#users-toolbar",
+                        title: tAdminUsers("toolbar.title"),
+                        description: tAdminUsers("toolbar.description"),
+                        side: "bottom",
+                    },
+                    {
+                        element: "#users-table",
+                        title: tAdminUsers("table.title"),
+                        description: tAdminUsers("table.description"),
+                        side: "top",
+                    },
+                ]}
+            />
+            <div className="flex flex-col gap-4 min-w-0 h-full">
+                <UsersTableWrapper users={users} currentUserId={session!.user.id} />
+            </div>
+        </>
     )
 }

--- a/src/app/(protected)/hours/components/editable-hour-cell.tsx
+++ b/src/app/(protected)/hours/components/editable-hour-cell.tsx
@@ -209,7 +209,7 @@ export function EditableHourCell({
     }
 
     return (
-        <div className="flex flex-col items-center gap-1 mx-auto w-20">
+        <div className="hours-editable-cell flex flex-col items-center gap-1 mx-auto w-20">
             <div
                 onClick={handleClick}
                 className={`h-8 w-16 text-center flex items-center justify-center cursor-pointer hover:bg-accent hover:text-accent-foreground rounded font-normal border border-transparent hover:border-border transition-colors ${

--- a/src/app/(protected)/hours/components/editable-hour-cell.tsx
+++ b/src/app/(protected)/hours/components/editable-hour-cell.tsx
@@ -209,7 +209,7 @@ export function EditableHourCell({
     }
 
     return (
-        <div className="hours-editable-cell flex flex-col items-center gap-1 mx-auto w-20">
+        <div className="flex flex-col items-center gap-1 mx-auto w-20">
             <div
                 onClick={handleClick}
                 className={`h-8 w-16 text-center flex items-center justify-center cursor-pointer hover:bg-accent hover:text-accent-foreground rounded font-normal border border-transparent hover:border-border transition-colors ${

--- a/src/app/(protected)/hours/components/hours-summary.tsx
+++ b/src/app/(protected)/hours/components/hours-summary.tsx
@@ -122,7 +122,7 @@ export function HoursSummary({
     const showBalance = dateRange && workingDays > 0
 
     return (
-        <Card>
+        <Card id="hours-summary">
             <CardContent className="p-2">
                 <div
                     className={`grid grid-cols-1 gap-2 w-full ${showWeekly ? "lg:grid-cols-[max-content_1fr]" : "lg:grid-cols-2"}`}

--- a/src/app/(protected)/hours/components/hours-table.tsx
+++ b/src/app/(protected)/hours/components/hours-table.tsx
@@ -74,7 +74,7 @@ export function HoursTable({
         })
 
         return (
-            <div className="rounded-md border overflow-x-auto">
+            <div id="hours-table" className="rounded-md border overflow-x-auto">
                 <Table>
                     <colgroup>
                         <col style={{ width: "200px", minWidth: "150px", maxWidth: "200px" }} />

--- a/src/app/(protected)/hours/components/hours-view.tsx
+++ b/src/app/(protected)/hours/components/hours-view.tsx
@@ -123,7 +123,7 @@ export function HoursView({
 
             <div className="space-y-2 pt-2">
                 <div className="flex items-center justify-between gap-2">
-                    <div className="flex items-center gap-2">
+                    <div id="hours-nav" className="flex items-center gap-2">
                         <Button
                             variant="outline"
                             size="sm"
@@ -186,6 +186,7 @@ export function HoursView({
                         </Button>
                         <div className="w-px h-6 bg-border mx-1" />
                         <Button
+                            id="hours-add-entry"
                             variant="default"
                             size="sm"
                             onClick={() => setIsFormOpen(true)}

--- a/src/app/(protected)/hours/page.tsx
+++ b/src/app/(protected)/hours/page.tsx
@@ -78,12 +78,6 @@ export default async function HoursPage({ searchParams }: HoursPageProps) {
                         description: tHours("table.description"),
                         side: "top",
                     },
-                    {
-                        element: ".hours-editable-cell",
-                        title: tHours("editCell.title"),
-                        description: tHours("editCell.description"),
-                        side: "top",
-                    },
                 ]}
             />
             <HoursView

--- a/src/app/(protected)/hours/page.tsx
+++ b/src/app/(protected)/hours/page.tsx
@@ -6,6 +6,8 @@ import { getDateRange } from "./utils/view-helpers"
 import { getHolidaysInRange } from "../admin/holidays/actions/holiday-actions"
 import type { ViewMode } from "./schemas/hour-filter-schemas"
 import { VIEW_MODE_VALUES } from "./schemas/hour-filter-schemas"
+import { getTranslations } from "next-intl/server"
+import { getTutorialsSeen, PageTour } from "@/features/tutorial"
 
 export const dynamic = "force-dynamic"
 
@@ -32,26 +34,70 @@ export default async function HoursPage({ searchParams }: HoursPageProps) {
     const weekRange = getDateRange(VIEW_MODE_VALUES.WEEKLY, selectedDate)
     const monthRange = getDateRange(VIEW_MODE_VALUES.MONTHLY, selectedDate)
 
-    const [entries, weeklyEntries, monthlyEntries, holidays, attendanceData] = await Promise.all([
+    const [entries, weeklyEntries, monthlyEntries, holidays, attendanceData, tutorialsSeen, tTutorial, tHours] = await Promise.all([
         getHourEntries(dateRange.startDate, dateRange.endDate),
         getHourEntries(weekRange.startDate, weekRange.endDate),
         getHourEntries(monthRange.startDate, monthRange.endDate),
         getHolidaysInRange(monthRange.startDate, monthRange.endDate),
         getAttendanceData(monthRange.startDate, monthRange.endDate),
+        getTutorialsSeen(),
+        getTranslations("tutorial"),
+        getTranslations("tutorial.hours"),
     ])
 
     return (
-        <HoursView
-            initialEntries={entries}
-            initialWeeklyEntries={weeklyEntries}
-            initialMonthlyEntries={monthlyEntries}
-            userId={session.user.id}
-            initialViewMode={viewMode}
-            initialSelectedDate={selectedDate}
-            initialHolidays={holidays}
-            initialDateRange={monthRange}
-            initialSummaryCollapsed={preferences.hoursCardCollapsed}
-            initialAttendanceData={attendanceData}
-        />
+        <>
+            <PageTour
+                pageKey="/hours"
+                seenPages={tutorialsSeen}
+                nextLabel={tTutorial("next")}
+                prevLabel={tTutorial("previous")}
+                doneLabel={tTutorial("done")}
+                steps={[
+                    {
+                        element: "#hours-summary",
+                        title: tHours("summary.title"),
+                        description: tHours("summary.description"),
+                        side: "bottom",
+                    },
+                    {
+                        element: "#hours-nav",
+                        title: tHours("navigation.title"),
+                        description: tHours("navigation.description"),
+                        side: "bottom",
+                    },
+                    {
+                        element: "#hours-add-entry",
+                        title: tHours("addEntry.title"),
+                        description: tHours("addEntry.description"),
+                        side: "bottom",
+                    },
+                    {
+                        element: "#hours-table",
+                        title: tHours("table.title"),
+                        description: tHours("table.description"),
+                        side: "top",
+                    },
+                    {
+                        element: ".hours-editable-cell",
+                        title: tHours("editCell.title"),
+                        description: tHours("editCell.description"),
+                        side: "top",
+                    },
+                ]}
+            />
+            <HoursView
+                initialEntries={entries}
+                initialWeeklyEntries={weeklyEntries}
+                initialMonthlyEntries={monthlyEntries}
+                userId={session.user.id}
+                initialViewMode={viewMode}
+                initialSelectedDate={selectedDate}
+                initialHolidays={holidays}
+                initialDateRange={monthRange}
+                initialSummaryCollapsed={preferences.hoursCardCollapsed}
+                initialAttendanceData={attendanceData}
+            />
+        </>
     )
 }

--- a/src/app/(protected)/requests/components/requests-table.tsx
+++ b/src/app/(protected)/requests/components/requests-table.tsx
@@ -74,7 +74,7 @@ export function RequestsTable({
 
     return (
         <>
-            <div className="flex items-center justify-between gap-4">
+            <div id="requests-controls" className="flex items-center justify-between gap-4">
                 <div className="relative flex-1 max-w-sm">
                     <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
                     <Input
@@ -85,13 +85,13 @@ export function RequestsTable({
                     />
                 </div>
                 {showNewButton && (
-                    <Button onClick={onNewRequestClick}>
+                    <Button id="requests-new-btn" onClick={onNewRequestClick}>
                         <Plus className="h-4 w-4 mr-2" />
                         {t("form.newRequest")}
                     </Button>
                 )}
             </div>
-            <div className="rounded-md border overflow-auto flex-1 min-h-0">
+            <div id="requests-table" className="rounded-md border overflow-auto flex-1 min-h-0">
                 <Table>
                     <TableHeader className="sticky top-0 z-10 bg-background">
                         <TableRow>

--- a/src/app/(protected)/requests/page.tsx
+++ b/src/app/(protected)/requests/page.tsx
@@ -4,6 +4,8 @@ import { prisma } from "@/lib/prisma"
 import { getUserRequests } from "./actions/request-actions"
 import { RequestsTableWithDialog } from "./components/requests-table-with-dialog"
 import { syncRequestStatuses } from "./actions/sync-request-statuses"
+import { getTranslations } from "next-intl/server"
+import { getTutorialsSeen, PageTour } from "@/features/tutorial"
 
 export default async function RequestsPage() {
     const session = await getServerSession(authConfig)
@@ -16,23 +18,55 @@ export default async function RequestsPage() {
         await syncRequestStatuses()
     }
 
-    const [requests, userRecord] = await Promise.all([
+    const [requests, userRecord, tutorialsSeen, tTutorial, tRequests] = await Promise.all([
         getUserRequests(),
         prisma.user.findUnique({
             where: { id: session.user.id },
             select: { urnikUsername: true },
         }),
+        getTutorialsSeen(),
+        getTranslations("tutorial"),
+        getTranslations("tutorial.requests"),
     ])
 
     const hasUrnikCredentials = !!userRecord?.urnikUsername
 
     return (
-        <div className="flex flex-col gap-4 min-w-0 h-full">
-            <RequestsTableWithDialog
-                requests={requests}
-                showUser={false}
-                hasUrnikCredentials={hasUrnikCredentials}
+        <>
+            <PageTour
+                pageKey="/requests"
+                seenPages={tutorialsSeen}
+                nextLabel={tTutorial("next")}
+                prevLabel={tTutorial("previous")}
+                doneLabel={tTutorial("done")}
+                steps={[
+                    {
+                        element: "#requests-controls",
+                        title: tRequests("controls.title"),
+                        description: tRequests("controls.description"),
+                        side: "bottom",
+                    },
+                    {
+                        element: "#requests-new-btn",
+                        title: tRequests("newRequest.title"),
+                        description: tRequests("newRequest.description"),
+                        side: "bottom",
+                    },
+                    {
+                        element: "#requests-table",
+                        title: tRequests("table.title"),
+                        description: tRequests("table.description"),
+                        side: "top",
+                    },
+                ]}
             />
-        </div>
+            <div className="flex flex-col gap-4 min-w-0 h-full">
+                <RequestsTableWithDialog
+                    requests={requests}
+                    showUser={false}
+                    hasUrnikCredentials={hasUrnikCredentials}
+                />
+            </div>
+        </>
     )
 }

--- a/src/app/(protected)/shifts/components/shifts-calendar-header.tsx
+++ b/src/app/(protected)/shifts/components/shifts-calendar-header.tsx
@@ -34,7 +34,7 @@ export function ShiftsCalendarHeader({
     return (
         <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-3 shrink-0">
             <div className="flex items-center justify-between lg:justify-start gap-2">
-                <div className="flex items-center gap-2">
+                <div id="shifts-nav-controls" className="flex items-center gap-2">
                     <Button variant="outline" size="sm" onClick={onPrevious}>
                         <ChevronLeft className="h-4 w-4" />
                     </Button>
@@ -77,7 +77,7 @@ export function ShiftsCalendarHeader({
                           year: "numeric",
                       })}
             </h2>
-            <div className="hidden lg:flex gap-2">
+            <div id="shifts-view-toggle" className="hidden lg:flex gap-2">
                 <Button
                     variant={viewMode === "week" ? "default" : "outline"}
                     size="sm"

--- a/src/app/(protected)/shifts/components/shifts-table.tsx
+++ b/src/app/(protected)/shifts/components/shifts-table.tsx
@@ -42,7 +42,7 @@ export function ShiftsTable({
     locationsShortTranslations,
 }: ShiftsTableProps) {
     return (
-        <div className="rounded-md border overflow-auto flex-1 min-h-0">
+        <div id="shifts-table" className="rounded-md border overflow-auto flex-1 min-h-0">
             <Table>
                 <TableHeader className="sticky top-0 z-30 bg-background">
                     <TableRow>
@@ -112,7 +112,7 @@ export function ShiftsTable({
                                 return (
                                     <TableCell
                                         key={date.toISOString()}
-                                        className={`text-center p-2 cursor-pointer ${
+                                        className={`shifts-cell text-center p-2 cursor-pointer ${
                                             isWeekend ? "bg-muted/50" : ""
                                         } ${holiday ? "bg-orange-100 dark:bg-orange-950" : ""} ${isToday(date) ? "bg-primary/5" : ""}`}
                                         onClick={() => onCellClick(date, user, shifts)}

--- a/src/app/(protected)/shifts/page.tsx
+++ b/src/app/(protected)/shifts/page.tsx
@@ -2,6 +2,7 @@ import { getTranslations } from "next-intl/server"
 import { getShiftsForPeriod, getAllUsers } from "./actions/shift-actions"
 import { getHolidaysInRange } from "../admin/holidays/actions/holiday-actions"
 import { ShiftsCalendar } from "./components/shifts-calendar"
+import { getTutorialsSeen, PageTour } from "@/features/tutorial"
 
 export const dynamic = "force-dynamic"
 
@@ -25,12 +26,15 @@ export default async function ShiftsPage({ searchParams }: ShiftsPageProps) {
         return `${year}-${month}-${day}`
     }
 
-    const [shiftsResult, usersResult, holidays, t, tShifts] = await Promise.all([
+    const [shiftsResult, usersResult, holidays, t, tShifts, tutorialsSeen, tTutorial, tShiftsTutorial] = await Promise.all([
         getShiftsForPeriod({ startDate, endDate }),
         getAllUsers(),
         getHolidaysInRange(formatDate(startDate), formatDate(endDate)),
         getTranslations("navigation"),
         getTranslations("shifts.messages"),
+        getTutorialsSeen(),
+        getTranslations("tutorial"),
+        getTranslations("tutorial.shifts"),
     ])
 
     if (shiftsResult.error || usersResult.error) {
@@ -61,6 +65,39 @@ export default async function ShiftsPage({ searchParams }: ShiftsPageProps) {
 
     return (
         <div className="flex flex-col gap-4 h-full">
+            <PageTour
+                pageKey="/shifts"
+                seenPages={tutorialsSeen}
+                nextLabel={tTutorial("next")}
+                prevLabel={tTutorial("previous")}
+                doneLabel={tTutorial("done")}
+                steps={[
+                    {
+                        element: "#shifts-nav-controls",
+                        title: tShiftsTutorial("navigation.title"),
+                        description: tShiftsTutorial("navigation.description"),
+                        side: "bottom",
+                    },
+                    {
+                        element: "#shifts-view-toggle",
+                        title: tShiftsTutorial("viewToggle.title"),
+                        description: tShiftsTutorial("viewToggle.description"),
+                        side: "bottom",
+                    },
+                    {
+                        element: "#shifts-table",
+                        title: tShiftsTutorial("calendar.title"),
+                        description: tShiftsTutorial("calendar.description"),
+                        side: "top",
+                    },
+                    {
+                        element: ".shifts-cell",
+                        title: tShiftsTutorial("cell.title"),
+                        description: tShiftsTutorial("cell.description"),
+                        side: "top",
+                    },
+                ]}
+            />
             <div className="flex-1 min-h-0">
                 <ShiftsCalendar
                     initialShifts={shiftsWithNormalizedDates}

--- a/src/app/(protected)/tasks/[listId]/page.tsx
+++ b/src/app/(protected)/tasks/[listId]/page.tsx
@@ -1,7 +1,9 @@
+import { getTranslations } from "next-intl/server"
 import { getTasks } from "../actions/task-actions"
 import { getListById, getLists } from "../actions/list-actions"
 import { TasksTable } from "../components/tasks-table"
 import { TasksViewClient } from "../components/tasks-view-client"
+import { getTutorialsSeen, PageTour } from "@/features/tutorial"
 
 interface ListPageProps {
     params: Promise<{
@@ -13,14 +15,50 @@ export default async function ListPage({ params }: ListPageProps) {
     const { listId } = await params
     const actualListId = listId === "no-list" ? null : listId
 
-    const [tasks, list, lists] = await Promise.all([
+    const [tasks, list, lists, tutorialsSeen, tTutorial, tTasksList] = await Promise.all([
         getTasks({ listId: actualListId }),
         actualListId ? getListById(actualListId) : null,
         getLists(),
+        getTutorialsSeen(),
+        getTranslations("tutorial"),
+        getTranslations("tutorial.tasksList"),
     ])
 
     return (
         <div className="flex flex-col h-full">
+            <PageTour
+                pageKey="/tasks/list"
+                seenPages={tutorialsSeen}
+                nextLabel={tTutorial("next")}
+                prevLabel={tTutorial("previous")}
+                doneLabel={tTutorial("done")}
+                steps={[
+                    {
+                        element: "#tasks-list-new-task",
+                        title: tTasksList("newTask.title"),
+                        description: tTasksList("newTask.description"),
+                        side: "bottom",
+                    },
+                    {
+                        element: ".tasks-status-section",
+                        title: tTasksList("statusSections.title"),
+                        description: tTasksList("statusSections.description"),
+                        side: "bottom",
+                    },
+                    {
+                        element: ".tasks-time-tracker",
+                        title: tTasksList("timer.title"),
+                        description: tTasksList("timer.description"),
+                        side: "left",
+                    },
+                    {
+                        element: ".tasks-row-actions",
+                        title: tTasksList("actions.title"),
+                        description: tTasksList("actions.description"),
+                        side: "left",
+                    },
+                ]}
+            />
             <div className="flex-none space-y-4">
                 <TasksViewClient listId={actualListId} />
             </div>

--- a/src/app/(protected)/tasks/components/overview-new-task-button.tsx
+++ b/src/app/(protected)/tasks/components/overview-new-task-button.tsx
@@ -14,7 +14,7 @@ export function OverviewNewTaskButton({ listId }: OverviewNewTaskButtonProps) {
     const openCreateDialog = useTasksStore((state) => state.openCreateDialog)
 
     return (
-        <Button onClick={() => openCreateDialog(undefined, listId)}>
+        <Button id="tasks-overview-new-task" onClick={() => openCreateDialog(undefined, listId)}>
             <Plus className="h-4 w-4 mr-2" />
             {t("newTask")}
         </Button>

--- a/src/app/(protected)/tasks/components/task-row.tsx
+++ b/src/app/(protected)/tasks/components/task-row.tsx
@@ -195,7 +195,7 @@ export function TaskRow({ task, lists }: TaskRowProps) {
                 <TableCell>
                     <TaskTimeTracker task={task} />
                 </TableCell>
-                <TableCell className="text-right">
+                <TableCell className="tasks-row-actions text-right">
                     <div className="flex gap-1 justify-end">
                         <Button
                             variant="ghost"

--- a/src/app/(protected)/tasks/components/task-time-tracker.tsx
+++ b/src/app/(protected)/tasks/components/task-time-tracker.tsx
@@ -105,14 +105,14 @@ export function TaskTimeTracker({ task }: TaskTimeTrackerProps) {
                     size="sm"
                     onClick={isRunning ? handleStop : handleStart}
                     disabled={isLoading}
-                    className="h-8 w-8 p-0"
+                    className="tasks-time-tracker h-8 w-8 p-0"
                     aria-label={isRunning ? t("stopTimer") : t("startTimer")}
                 >
                     {isRunning ? <Square className="h-4 w-4" /> : <Play className="h-4 w-4" />}
                 </Button>
                 <button
                     onClick={handleClick}
-                    className="text-sm font-mono hover:underline cursor-pointer"
+                    className="tasks-time-entries-btn text-sm font-mono hover:underline cursor-pointer"
                 >
                     {isRunning
                         ? formatDuration(elapsedSeconds)

--- a/src/app/(protected)/tasks/components/tasks-overview-client.tsx
+++ b/src/app/(protected)/tasks/components/tasks-overview-client.tsx
@@ -87,7 +87,7 @@ export function TasksOverviewClient({ groups, lists: initialLists }: TasksOvervi
         <div className="space-y-8">
             {groups.map((group) => {
                 return (
-                    <div key={group.listId ?? "no-list"} className="space-y-3">
+                    <div key={group.listId ?? "no-list"} className="tasks-overview-group space-y-3">
                         <div className="flex items-center justify-between">
                             <div className="flex items-center gap-3">
                                 {group.listColor && (

--- a/src/app/(protected)/tasks/components/tasks-table.tsx
+++ b/src/app/(protected)/tasks/components/tasks-table.tsx
@@ -50,7 +50,7 @@ export function TasksTable({ tasks, listId, lists }: TasksTableProps) {
                     <div key={group.status} className="rounded-md border overflow-x-auto">
                         <button
                             onClick={() => toggleStatusSection(listId, group.status)}
-                            className="w-full bg-muted/50 px-4 py-3 border-b hover:bg-muted transition-colors"
+                            className="tasks-status-section w-full bg-muted/50 px-4 py-3 border-b hover:bg-muted transition-colors"
                         >
                             <div className="flex items-center gap-2">
                                 {isExpanded ? (

--- a/src/app/(protected)/tasks/components/tasks-view-client.tsx
+++ b/src/app/(protected)/tasks/components/tasks-view-client.tsx
@@ -82,7 +82,7 @@ export function TasksViewClient({ listId }: TasksViewClientProps) {
     return (
         <>
             <div className="flex items-center justify-end w-full">
-                <Button onClick={() => openCreateDialog()}>
+                <Button id="tasks-list-new-task" onClick={() => openCreateDialog()}>
                     <Plus className="h-4 w-4 mr-2" />
                     {t("newTask")}
                 </Button>

--- a/src/app/(protected)/tasks/page.tsx
+++ b/src/app/(protected)/tasks/page.tsx
@@ -1,9 +1,17 @@
+import { getTranslations } from "next-intl/server"
 import { getInProgressTasksByLists } from "./actions/task-actions"
 import { getLists } from "./actions/list-actions"
 import { TasksOverview } from "./components/tasks-overview"
+import { getTutorialsSeen, PageTour } from "@/features/tutorial"
 
 export default async function TasksPage() {
-    const [groupedTasks, lists] = await Promise.all([getInProgressTasksByLists(), getLists()])
+    const [groupedTasks, lists, tutorialsSeen, tTutorial, tTasks] = await Promise.all([
+        getInProgressTasksByLists(),
+        getLists(),
+        getTutorialsSeen(),
+        getTranslations("tutorial"),
+        getTranslations("tutorial.tasks"),
+    ])
 
     const tasksByListId = new Map(groupedTasks.map((group) => [group.listId ?? "no-list", group]))
 
@@ -26,6 +34,39 @@ export default async function TasksPage() {
 
     return (
         <div className="h-full overflow-auto">
+            <PageTour
+                pageKey="/tasks"
+                seenPages={tutorialsSeen}
+                nextLabel={tTutorial("next")}
+                prevLabel={tTutorial("previous")}
+                doneLabel={tTutorial("done")}
+                steps={[
+                    {
+                        element: "#tasks-overview-new-task",
+                        title: tTasks("newTask.title"),
+                        description: tTasks("newTask.description"),
+                        side: "bottom",
+                    },
+                    {
+                        element: ".tasks-overview-group",
+                        title: tTasks("groups.title"),
+                        description: tTasks("groups.description"),
+                        side: "bottom",
+                    },
+                    {
+                        element: ".tasks-time-tracker",
+                        title: tTasks("timer.title"),
+                        description: tTasks("timer.description"),
+                        side: "left",
+                    },
+                    {
+                        element: ".tasks-time-entries-btn",
+                        title: tTasks("timeEntries.title"),
+                        description: tTasks("timeEntries.description"),
+                        side: "left",
+                    },
+                ]}
+            />
             <TasksOverview groups={allGroups} lists={lists} />
         </div>
     )

--- a/src/app/(protected)/time-sheets/components/time-sheets-client.tsx
+++ b/src/app/(protected)/time-sheets/components/time-sheets-client.tsx
@@ -216,7 +216,7 @@ export function TimeSheetsClient({
                     </div>
 
                     <div className="flex items-center gap-2">
-                        <div className="text-sm hidden md:block">
+                        <div id="time-sheets-balance" className="text-sm hidden md:block">
                             <span className="font-semibold">
                                 {formatHoursMinutesLib(totalSeconds)}
                             </span>

--- a/src/app/(protected)/time-sheets/components/time-sheets-table.tsx
+++ b/src/app/(protected)/time-sheets/components/time-sheets-table.tsx
@@ -135,7 +135,7 @@ export function TimeSheetsTable({
 
     return (
         <>
-            <div className="border rounded-lg overflow-auto h-full">
+            <div id="time-sheets-table" className="border rounded-lg overflow-auto h-full">
                 <Table>
                     <colgroup>
                         <col style={{ width: "180px", minWidth: "150px", maxWidth: "200px" }} />
@@ -144,7 +144,10 @@ export function TimeSheetsTable({
                         ))}
                         <col style={{ width: "100px", minWidth: "100px" }} />
                     </colgroup>
-                    <TableHeader className="sticky top-0 z-30 bg-background">
+                    <TableHeader
+                        id="time-sheets-table-header"
+                        className="sticky top-0 z-30 bg-background"
+                    >
                         <TableRow>
                             <TableHead className="sticky left-0 z-40 bg-background border-r font-semibold min-w-[150px] max-w-[200px] py-2">
                                 {translations.task}
@@ -160,7 +163,7 @@ export function TimeSheetsTable({
                                 return (
                                     <TableHead
                                         key={dateStr}
-                                        className={`text-center min-w-[100px] relative py-2 ${
+                                        className={`time-sheets-date-header text-center min-w-[100px] relative py-2 ${
                                             isWeekendDay ? "bg-muted/50" : ""
                                         } ${holiday ? "bg-orange-100 dark:bg-orange-950" : ""} ${isTodayDay ? "bg-blue-50 dark:bg-blue-950" : ""}`}
                                     >
@@ -364,7 +367,7 @@ export function TimeSheetsTable({
                                                         }`}
                                                     >
                                                         <span
-                                                            className={`${
+                                                            className={`time-sheets-task-cell ${
                                                                 displayDuration
                                                                     ? "cursor-pointer hover:underline"
                                                                     : ""

--- a/src/app/(protected)/time-sheets/components/time-sheets-view.tsx
+++ b/src/app/(protected)/time-sheets/components/time-sheets-view.tsx
@@ -72,7 +72,7 @@ export async function TimeSheetsView({ searchParams, initialHolidays = [] }: Tim
                 doneLabel={tTutorial("done")}
                 steps={[
                     {
-                        element: "#time-sheets-table-header",
+                        element: "#time-sheets-table",
                         title: tTimeSheetsToure("table.title"),
                         description: tTimeSheetsToure("table.description"),
                         side: "bottom",

--- a/src/app/(protected)/time-sheets/components/time-sheets-view.tsx
+++ b/src/app/(protected)/time-sheets/components/time-sheets-view.tsx
@@ -7,6 +7,7 @@ import { getDateRangeForView, type ViewMode } from "../utils/date-helpers"
 import { getCurrentUser } from "../../profile/actions/profile-actions"
 import { aggregateTimeEntriesByTaskAndDate } from "../utils/aggregation-helpers"
 import { calculateExpectedHoursToDate, calculateBalance } from "@/lib/balance-helpers"
+import { getTutorialsSeen, PageTour } from "@/features/tutorial"
 
 interface TimeSheetsViewProps {
     searchParams: { mode?: string; date?: string; filter?: string }
@@ -17,21 +18,26 @@ export async function TimeSheetsView({ searchParams, initialHolidays = [] }: Tim
     const t = await getTranslations("timeSheets")
     const tSummary = await getTranslations("hours.summary")
     const tDialog = await getTranslations("timeSheets.dayEntriesDialog")
+    const tTutorial = await getTranslations("tutorial")
+    const tTimeSheetsToure = await getTranslations("tutorial.timeSheets")
 
     const viewMode = (searchParams.mode === "month" ? "month" : "week") as ViewMode
     const selectedDate = searchParams.date ? new Date(searchParams.date) : new Date()
     const taskFilter = searchParams.filter === "private" ? "private" : "work"
 
     const dateRange = getDateRangeForView(selectedDate, viewMode)
-    const result = await getTimeSheetEntries({
-        startDate: dateRange.startDate.toISOString(),
-        endDate: dateRange.endDate.toISOString(),
-        taskFilter,
-    })
+    const [result, currentUser, tutorialsSeen] = await Promise.all([
+        getTimeSheetEntries({
+            startDate: dateRange.startDate.toISOString(),
+            endDate: dateRange.endDate.toISOString(),
+            taskFilter,
+        }),
+        getCurrentUser(),
+        getTutorialsSeen(),
+    ])
 
     const initialData = "data" in result && result.data ? result.data : []
 
-    const currentUser = await getCurrentUser()
     const userWorkHoursPerDay = currentUser?.workHoursPerDay || 8
 
     const aggregatedData = aggregateTimeEntriesByTaskAndDate(
@@ -58,6 +64,39 @@ export async function TimeSheetsView({ searchParams, initialHolidays = [] }: Tim
 
     return (
         <>
+            <PageTour
+                pageKey="/time-sheets"
+                seenPages={tutorialsSeen}
+                nextLabel={tTutorial("next")}
+                prevLabel={tTutorial("previous")}
+                doneLabel={tTutorial("done")}
+                steps={[
+                    {
+                        element: "#time-sheets-table-header",
+                        title: tTimeSheetsToure("table.title"),
+                        description: tTimeSheetsToure("table.description"),
+                        side: "bottom",
+                    },
+                    {
+                        element: ".time-sheets-task-cell",
+                        title: tTimeSheetsToure("taskCell.title"),
+                        description: tTimeSheetsToure("taskCell.description"),
+                        side: "top",
+                    },
+                    {
+                        element: ".time-sheets-date-header",
+                        title: tTimeSheetsToure("dateCell.title"),
+                        description: tTimeSheetsToure("dateCell.description"),
+                        side: "bottom",
+                    },
+                    {
+                        element: "#time-sheets-balance",
+                        title: tTimeSheetsToure("balance.title"),
+                        description: tTimeSheetsToure("balance.description"),
+                        side: "bottom",
+                    },
+                ]}
+            />
             <TimeSheetsClient
                 initialData={initialData}
                 initialViewMode={viewMode}

--- a/src/app/(protected)/tracker/components/tracker-display.tsx
+++ b/src/app/(protected)/tracker/components/tracker-display.tsx
@@ -209,6 +209,7 @@ export function TrackerDisplay({
                                     -
                                 </label>
                                 <Button
+                                    id="tracker-time-entries"
                                     variant="outline"
                                     onClick={handleViewEntries}
                                     disabled={taskEntries.length === 0}

--- a/src/app/(protected)/tracker/components/tracker-display.tsx
+++ b/src/app/(protected)/tracker/components/tracker-display.tsx
@@ -136,7 +136,11 @@ export function TrackerDisplay({
                                 onValueChange={handleTypeChange}
                                 disabled={isLoading}
                             >
-                                <SelectTrigger className="w-full" suppressHydrationWarning>
+                                <SelectTrigger
+                                    id="tracker-hour-type"
+                                    className="w-full"
+                                    suppressHydrationWarning
+                                >
                                     <SelectValue>{getTypeLabel(selectedType)}</SelectValue>
                                 </SelectTrigger>
                                 <SelectContent>
@@ -157,7 +161,11 @@ export function TrackerDisplay({
                                     onValueChange={handleTaskChange}
                                     disabled={selectedType !== "WORK" || isLoading}
                                 >
-                                    <SelectTrigger className="w-full" suppressHydrationWarning>
+                                    <SelectTrigger
+                                        id="tracker-task-select"
+                                        className="w-full"
+                                        suppressHydrationWarning
+                                    >
                                         <SelectValue>{getSelectedTaskLabel()}</SelectValue>
                                     </SelectTrigger>
                                     <SelectContent className="max-h-[300px]">
@@ -239,6 +247,7 @@ export function TrackerDisplay({
                             </div>
 
                             <Button
+                                id="tracker-timer-button"
                                 size="lg"
                                 onClick={handlePlayStop}
                                 disabled={isLoading || (!isTrackingCurrentSelection && !canStart)}
@@ -256,7 +265,7 @@ export function TrackerDisplay({
                             </Button>
                         </div>
 
-                        <div className="xl:col-span-2">
+                        <div id="tracker-daily-summary" className="xl:col-span-2">
                             <DailySummaryCard
                                 initialData={initialDailySummary}
                                 translations={{

--- a/src/app/(protected)/tracker/page.tsx
+++ b/src/app/(protected)/tracker/page.tsx
@@ -94,6 +94,12 @@ export default async function TrackerPage() {
                         side: "bottom",
                     },
                     {
+                        element: "#tracker-time-entries",
+                        title: tTrackerTour("timeEntries.title"),
+                        description: tTrackerTour("timeEntries.description"),
+                        side: "bottom",
+                    },
+                    {
                         element: "#tracker-timer-button",
                         title: tTrackerTour("timerButton.title"),
                         description: tTrackerTour("timerButton.description"),

--- a/src/app/(protected)/tracker/page.tsx
+++ b/src/app/(protected)/tracker/page.tsx
@@ -12,6 +12,7 @@ import { TrackerDisplay } from "./components/tracker-display"
 import { TimeEntriesDialog } from "@/app/(protected)/tasks/components/time-entries-dialog"
 import { DayEntriesDialog } from "@/app/(protected)/time-sheets/components/day-entries-dialog"
 import { getTranslations } from "next-intl/server"
+import { getTutorialsSeen, PageTour } from "@/features/tutorial"
 
 export default async function TrackerPage() {
     const t = await getTranslations("tasks.tracker")
@@ -19,15 +20,24 @@ export default async function TrackerPage() {
     const tDialog = await getTranslations("timeSheets.dayEntriesDialog")
     const tClock = await getTranslations("clock")
     const tCommon = await getTranslations("common")
+    const tTutorial = await getTranslations("tutorial")
+    const tTrackerTour = await getTranslations("tutorial.tracker")
 
-    const [inProgressTasks, activeTimer, generalWorkTask, trackerPreferences, dailySummary] =
-        await Promise.all([
-            getTasks({ status: TASK_STATUS.IN_PROGRESS }),
-            getActiveTimer(),
-            getGeneralWorkTask(),
-            getTrackerPreferences(),
-            getTodayTimeSummary(),
-        ])
+    const [
+        inProgressTasks,
+        activeTimer,
+        generalWorkTask,
+        trackerPreferences,
+        dailySummary,
+        tutorialsSeen,
+    ] = await Promise.all([
+        getTasks({ status: TASK_STATUS.IN_PROGRESS }),
+        getActiveTimer(),
+        getGeneralWorkTask(),
+        getTrackerPreferences(),
+        getTodayTimeSummary(),
+        getTutorialsSeen(),
+    ])
 
     let finalSelectedTaskId = trackerPreferences.selectedTaskId
 
@@ -64,6 +74,39 @@ export default async function TrackerPage() {
 
     return (
         <div className="flex flex-col h-full overflow-hidden">
+            <PageTour
+                pageKey="/tracker"
+                seenPages={tutorialsSeen}
+                nextLabel={tTutorial("next")}
+                prevLabel={tTutorial("previous")}
+                doneLabel={tTutorial("done")}
+                steps={[
+                    {
+                        element: "#tracker-hour-type",
+                        title: tTrackerTour("hourType.title"),
+                        description: tTrackerTour("hourType.description"),
+                        side: "bottom",
+                    },
+                    {
+                        element: "#tracker-task-select",
+                        title: tTrackerTour("taskSelect.title"),
+                        description: tTrackerTour("taskSelect.description"),
+                        side: "bottom",
+                    },
+                    {
+                        element: "#tracker-timer-button",
+                        title: tTrackerTour("timerButton.title"),
+                        description: tTrackerTour("timerButton.description"),
+                        side: "top",
+                    },
+                    {
+                        element: "#tracker-daily-summary",
+                        title: tTrackerTour("dailySummary.title"),
+                        description: tTrackerTour("dailySummary.description"),
+                        side: "left",
+                    },
+                ]}
+            />
             <div className="flex-1 overflow-auto">
                 <TrackerDisplay
                     inProgressTasks={inProgressTasks}

--- a/src/app/(protected)/urnik-net-overview/components/clock-view.tsx
+++ b/src/app/(protected)/urnik-net-overview/components/clock-view.tsx
@@ -74,7 +74,7 @@ export function ClockView({ translations, status, hasApprovedWFH, wfhLocation }:
 
     return (
         <div className="space-y-6">
-            <Card>
+            <Card id="urnik-clock-card">
                 <CardHeader>
                     <CardTitle className="flex items-center gap-2">
                         <Clock className="h-5 w-5" />
@@ -133,7 +133,7 @@ export function ClockView({ translations, status, hasApprovedWFH, wfhLocation }:
             </Card>
 
             <div className="grid gap-6 md:grid-cols-2">
-                <Card>
+                <Card id="urnik-work-time">
                     <CardHeader>
                         <CardTitle className="flex items-center gap-2">
                             <Clock className="h-5 w-5" />
@@ -151,7 +151,7 @@ export function ClockView({ translations, status, hasApprovedWFH, wfhLocation }:
                     </CardContent>
                 </Card>
 
-                <Card>
+                <Card id="urnik-balance">
                     <CardHeader>
                         <CardTitle className="flex items-center gap-2">
                             <TrendingUp className="h-5 w-5" />
@@ -174,7 +174,7 @@ export function ClockView({ translations, status, hasApprovedWFH, wfhLocation }:
                 </Card>
             </div>
 
-            <Card>
+            <Card id="urnik-vacation">
                 <CardHeader>
                     <CardTitle className="flex items-center gap-2">
                         <Calendar className="h-5 w-5" />

--- a/src/app/(protected)/urnik-net-overview/hours/components/hours-view.tsx
+++ b/src/app/(protected)/urnik-net-overview/hours/components/hours-view.tsx
@@ -67,7 +67,7 @@ export function HoursView({
 
     return (
         <div className="flex flex-col gap-4 h-full">
-            <div className="flex items-center justify-between gap-2">
+            <div id="urnik-hours-nav" className="flex items-center justify-between gap-2">
                 <div className="flex items-center gap-1 sm:gap-2">
                     <Button
                         variant="outline"
@@ -106,7 +106,7 @@ export function HoursView({
                         </div>
                         <Dialog>
                             <DialogTrigger asChild>
-                                <Button variant="outline" size="sm">
+                                <Button id="urnik-hours-details" variant="outline" size="sm">
                                     {translations.detailsButton}
                                 </Button>
                             </DialogTrigger>
@@ -233,7 +233,7 @@ export function HoursView({
 
             {days.length > 0 && (
                 <div className="flex-1 overflow-hidden relative">
-                    <div className="rounded-md border overflow-auto h-full">
+                    <div id="urnik-hours-table" className="rounded-md border overflow-auto h-full">
                         <Table>
                             <TableHeader className="sticky top-0 z-30 bg-background">
                                 <TableRow>

--- a/src/app/(protected)/urnik-net-overview/hours/page.tsx
+++ b/src/app/(protected)/urnik-net-overview/hours/page.tsx
@@ -3,6 +3,7 @@ import { requireAuth } from "@/lib/auth-helpers"
 import { getTranslations } from "next-intl/server"
 import { fetchMonthlyHours } from "./actions/hours-actions"
 import { HoursView } from "./components/hours-view"
+import { getTutorialsSeen, PageTour } from "@/features/tutorial"
 
 export const dynamic = "force-dynamic"
 
@@ -13,8 +14,13 @@ export default async function UrnikNetHoursPage({
 }) {
     await requireAuth().catch(() => redirect("/login"))
 
-    const t = await getTranslations("urnikNetHours")
-    const tYearlyCalendar = await getTranslations("yearlyCalendar")
+    const [t, tYearlyCalendar, tTutorial, tPage, tutorialsSeen] = await Promise.all([
+        getTranslations("urnikNetHours"),
+        getTranslations("yearlyCalendar"),
+        getTranslations("tutorial"),
+        getTranslations("tutorial.urnikNetHours"),
+        getTutorialsSeen(),
+    ])
 
     const params = await searchParams
     const today = new Date()
@@ -26,7 +32,35 @@ export default async function UrnikNetHoursPage({
     const result = await fetchMonthlyHours(currentYear, currentMonth)
 
     return (
-        <div className="flex flex-col gap-4 h-full">
+        <>
+            <PageTour
+                pageKey="/urnik-net-overview/hours"
+                seenPages={tutorialsSeen}
+                nextLabel={tTutorial("next")}
+                prevLabel={tTutorial("prev")}
+                doneLabel={tTutorial("done")}
+                steps={[
+                    {
+                        element: "#urnik-hours-nav",
+                        title: tPage("nav.title"),
+                        description: tPage("nav.description"),
+                        side: "bottom",
+                    },
+                    {
+                        element: "#urnik-hours-details",
+                        title: tPage("details.title"),
+                        description: tPage("details.description"),
+                        side: "bottom",
+                    },
+                    {
+                        element: "#urnik-hours-table",
+                        title: tPage("table.title"),
+                        description: tPage("table.description"),
+                        side: "top",
+                    },
+                ]}
+            />
+            <div className="flex flex-col gap-4 h-full">
             <HoursView
                 result={result}
                 currentYear={currentYear}
@@ -67,5 +101,6 @@ export default async function UrnikNetHoursPage({
                 }}
             />
         </div>
+        </>
     )
 }

--- a/src/app/(protected)/urnik-net-overview/hours/page.tsx
+++ b/src/app/(protected)/urnik-net-overview/hours/page.tsx
@@ -37,7 +37,7 @@ export default async function UrnikNetHoursPage({
                 pageKey="/urnik-net-overview/hours"
                 seenPages={tutorialsSeen}
                 nextLabel={tTutorial("next")}
-                prevLabel={tTutorial("prev")}
+                prevLabel={tTutorial("previous")}
                 doneLabel={tTutorial("done")}
                 steps={[
                     {
@@ -61,46 +61,46 @@ export default async function UrnikNetHoursPage({
                 ]}
             />
             <div className="flex flex-col gap-4 h-full">
-            <HoursView
-                result={result}
-                currentYear={currentYear}
-                currentMonth={currentMonth}
-                monthName={monthName}
-                translations={{
-                    previousMonth: t("previousMonth"),
-                    nextMonth: t("nextMonth"),
-                    detailsButton: t("detailsButton"),
-                    summary: {
-                        billingHours: t("summary.billingHours"),
-                        plannedHours: t("summary.plannedHours"),
-                        workDays: t("summary.workDays"),
-                        holidays: t("summary.holidays"),
-                        lunches: t("summary.lunches"),
-                        vacationBalance: t("summary.vacationBalance"),
-                        vacationBalanceShort: t("summary.vacationBalanceShort"),
-                        sickLeave: t("summary.sickLeave"),
-                        leaveDays: t("summary.leaveDays"),
-                        balance: t("summary.balance"),
-                        workFromHome: t("summary.workFromHome"),
-                        userType: t("summary.userType"),
-                        hoursInDay: t("summary.hoursInDay"),
-                    },
-                    table: {
-                        no: t("table.no"),
-                        date: t("table.date"),
-                        day: t("table.day"),
-                        status: t("table.status"),
-                        clockIn: t("table.clockIn"),
-                        clockOut: t("table.clockOut"),
-                        attendance: t("table.attendance"),
-                        accounted: t("table.accounted"),
-                        dayBalance: t("table.dayBalance"),
-                        balanceMonth: t("table.balanceMonth"),
-                        balanceYear: t("table.balanceYear"),
-                    },
-                }}
-            />
-        </div>
+                <HoursView
+                    result={result}
+                    currentYear={currentYear}
+                    currentMonth={currentMonth}
+                    monthName={monthName}
+                    translations={{
+                        previousMonth: t("previousMonth"),
+                        nextMonth: t("nextMonth"),
+                        detailsButton: t("detailsButton"),
+                        summary: {
+                            billingHours: t("summary.billingHours"),
+                            plannedHours: t("summary.plannedHours"),
+                            workDays: t("summary.workDays"),
+                            holidays: t("summary.holidays"),
+                            lunches: t("summary.lunches"),
+                            vacationBalance: t("summary.vacationBalance"),
+                            vacationBalanceShort: t("summary.vacationBalanceShort"),
+                            sickLeave: t("summary.sickLeave"),
+                            leaveDays: t("summary.leaveDays"),
+                            balance: t("summary.balance"),
+                            workFromHome: t("summary.workFromHome"),
+                            userType: t("summary.userType"),
+                            hoursInDay: t("summary.hoursInDay"),
+                        },
+                        table: {
+                            no: t("table.no"),
+                            date: t("table.date"),
+                            day: t("table.day"),
+                            status: t("table.status"),
+                            clockIn: t("table.clockIn"),
+                            clockOut: t("table.clockOut"),
+                            attendance: t("table.attendance"),
+                            accounted: t("table.accounted"),
+                            dayBalance: t("table.dayBalance"),
+                            balanceMonth: t("table.balanceMonth"),
+                            balanceYear: t("table.balanceYear"),
+                        },
+                    }}
+                />
+            </div>
         </>
     )
 }

--- a/src/app/(protected)/urnik-net-overview/page.tsx
+++ b/src/app/(protected)/urnik-net-overview/page.tsx
@@ -5,15 +5,20 @@ import { ClockView } from "./components/clock-view"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { AlertCircle } from "lucide-react"
 import { getArrivalLeaveStatus, getTodayWorkFromHomeStatus } from "@/lib/clock-status"
+import { getTutorialsSeen, PageTour } from "@/features/tutorial"
 
 export default async function ClockPage() {
     await requireAuth().catch(() => redirect("/login"))
 
-    const t = await getTranslations("clock")
-    const tCommon = await getTranslations("common")
-
-    const status = await getArrivalLeaveStatus()
-    const wfhStatus = await getTodayWorkFromHomeStatus()
+    const [t, tCommon, tTutorial, tPage, tutorialsSeen, status, wfhStatus] = await Promise.all([
+        getTranslations("clock"),
+        getTranslations("common"),
+        getTranslations("tutorial"),
+        getTranslations("tutorial.urnikNetClock"),
+        getTutorialsSeen(),
+        getArrivalLeaveStatus(),
+        getTodayWorkFromHomeStatus(),
+    ])
 
     const translations = {
         title: t("view.title"),
@@ -50,27 +55,62 @@ export default async function ClockPage() {
     }
 
     return (
-        <div className="space-y-6">
-            {!status.success && (
-                <Alert variant="destructive">
-                    <AlertCircle className="h-4 w-4" />
-                    <AlertTitle>{t("messages.errorLoadingDayInfo")}</AlertTitle>
-                    <AlertDescription>{status.error}</AlertDescription>
-                </Alert>
-            )}
-            {status.success && status.structureValid === false && (
-                <Alert variant="default">
-                    <AlertCircle className="h-4 w-4" />
-                    <AlertTitle>{t("messages.structureChangedWarning")}</AlertTitle>
-                    <AlertDescription>{t("messages.structureChangedDescription")}</AlertDescription>
-                </Alert>
-            )}
-            <ClockView
-                translations={translations}
-                status={status}
-                hasApprovedWFH={wfhStatus.hasApprovedWFH}
-                wfhLocation={wfhStatus.location}
+        <>
+            <PageTour
+                pageKey="/urnik-net-overview"
+                seenPages={tutorialsSeen}
+                nextLabel={tTutorial("next")}
+                prevLabel={tTutorial("prev")}
+                doneLabel={tTutorial("done")}
+                steps={[
+                    {
+                        element: "#urnik-clock-card",
+                        title: tPage("clockCard.title"),
+                        description: tPage("clockCard.description"),
+                        side: "bottom",
+                    },
+                    {
+                        element: "#urnik-work-time",
+                        title: tPage("workTime.title"),
+                        description: tPage("workTime.description"),
+                        side: "bottom",
+                    },
+                    {
+                        element: "#urnik-balance",
+                        title: tPage("balance.title"),
+                        description: tPage("balance.description"),
+                        side: "bottom",
+                    },
+                    {
+                        element: "#urnik-vacation",
+                        title: tPage("vacation.title"),
+                        description: tPage("vacation.description"),
+                        side: "bottom",
+                    },
+                ]}
             />
-        </div>
+            <div className="space-y-6">
+                {!status.success && (
+                    <Alert variant="destructive">
+                        <AlertCircle className="h-4 w-4" />
+                        <AlertTitle>{t("messages.errorLoadingDayInfo")}</AlertTitle>
+                        <AlertDescription>{status.error}</AlertDescription>
+                    </Alert>
+                )}
+                {status.success && status.structureValid === false && (
+                    <Alert variant="default">
+                        <AlertCircle className="h-4 w-4" />
+                        <AlertTitle>{t("messages.structureChangedWarning")}</AlertTitle>
+                        <AlertDescription>{t("messages.structureChangedDescription")}</AlertDescription>
+                    </Alert>
+                )}
+                <ClockView
+                    translations={translations}
+                    status={status}
+                    hasApprovedWFH={wfhStatus.hasApprovedWFH}
+                    wfhLocation={wfhStatus.location}
+                />
+            </div>
+        </>
     )
 }

--- a/src/app/(protected)/urnik-net-overview/page.tsx
+++ b/src/app/(protected)/urnik-net-overview/page.tsx
@@ -60,7 +60,7 @@ export default async function ClockPage() {
                 pageKey="/urnik-net-overview"
                 seenPages={tutorialsSeen}
                 nextLabel={tTutorial("next")}
-                prevLabel={tTutorial("prev")}
+                prevLabel={tTutorial("previous")}
                 doneLabel={tTutorial("done")}
                 steps={[
                     {
@@ -101,7 +101,9 @@ export default async function ClockPage() {
                     <Alert variant="default">
                         <AlertCircle className="h-4 w-4" />
                         <AlertTitle>{t("messages.structureChangedWarning")}</AlertTitle>
-                        <AlertDescription>{t("messages.structureChangedDescription")}</AlertDescription>
+                        <AlertDescription>
+                            {t("messages.structureChangedDescription")}
+                        </AlertDescription>
                     </Alert>
                 )}
                 <ClockView

--- a/src/app/(protected)/urnik-net-overview/requests/components/urnik-net-requests-view.tsx
+++ b/src/app/(protected)/urnik-net-overview/requests/components/urnik-net-requests-view.tsx
@@ -91,7 +91,7 @@ export function UrnikNetRequestsView({
 
     return (
         <div className="flex flex-col gap-4 h-full">
-            <div className="flex items-center justify-between gap-2">
+            <div id="urnik-requests-nav" className="flex items-center justify-between gap-2">
                 <div className="flex items-center gap-1 sm:gap-2">
                     <Button
                         variant="outline"
@@ -155,7 +155,7 @@ export function UrnikNetRequestsView({
 
             {allRows.length > 0 && (
                 <div className="flex-1 overflow-hidden relative">
-                    <div className="rounded-md border overflow-auto h-full">
+                    <div id="urnik-requests-table" className="rounded-md border overflow-auto h-full">
                         <Table>
                             <RequestsTableHeader {...t.table} />
                             <TableBody>

--- a/src/app/(protected)/urnik-net-overview/requests/page.tsx
+++ b/src/app/(protected)/urnik-net-overview/requests/page.tsx
@@ -13,6 +13,7 @@ import {
     getSubmittedUrnikNetRequests,
 } from "./actions/urnik-net-requests-actions"
 import { syncRequestStatuses } from "../../requests/actions/sync-request-statuses"
+import { getTutorialsSeen, PageTour } from "@/features/tutorial"
 
 export const dynamic = "force-dynamic"
 
@@ -85,6 +86,11 @@ export default async function UrnikNetRequestsPage({
 
     const t = await getTranslations("clock.urnikNetRequests")
     const tCreateRequest = await getTranslations("urnikNetOverview.createRequest")
+    const [tTutorial, tPage, tutorialsSeen] = await Promise.all([
+        getTranslations("tutorial"),
+        getTranslations("tutorial.urnikNetRequests"),
+        getTutorialsSeen(),
+    ])
 
     const urnikNetTranslations = {
         pageTitle: t("pageTitle"),
@@ -129,16 +135,39 @@ export default async function UrnikNetRequestsPage({
     }
 
     return (
-        <div className="flex flex-col gap-4 h-full">
-            <UrnikNetRequestsView
-                user={user}
-                translations={urnikNetTranslations}
-                requestsResult={requestsResult}
-                pendingRequestsResult={pendingRequestsResult}
-                submittedRequests={submittedRequests}
-                currentMonth={currentMonth}
+        <>
+            <PageTour
+                pageKey="/urnik-net-overview/requests"
+                seenPages={tutorialsSeen}
+                nextLabel={tTutorial("next")}
+                prevLabel={tTutorial("prev")}
+                doneLabel={tTutorial("done")}
+                steps={[
+                    {
+                        element: "#urnik-requests-nav",
+                        title: tPage("nav.title"),
+                        description: tPage("nav.description"),
+                        side: "bottom",
+                    },
+                    {
+                        element: "#urnik-requests-table",
+                        title: tPage("table.title"),
+                        description: tPage("table.description"),
+                        side: "top",
+                    },
+                ]}
             />
-            <CreateRequestDialog />
-        </div>
+            <div className="flex flex-col gap-4 h-full">
+                <UrnikNetRequestsView
+                    user={user}
+                    translations={urnikNetTranslations}
+                    requestsResult={requestsResult}
+                    pendingRequestsResult={pendingRequestsResult}
+                    submittedRequests={submittedRequests}
+                    currentMonth={currentMonth}
+                />
+                <CreateRequestDialog />
+            </div>
+        </>
     )
 }

--- a/src/app/(protected)/urnik-net-overview/requests/page.tsx
+++ b/src/app/(protected)/urnik-net-overview/requests/page.tsx
@@ -140,7 +140,7 @@ export default async function UrnikNetRequestsPage({
                 pageKey="/urnik-net-overview/requests"
                 seenPages={tutorialsSeen}
                 nextLabel={tTutorial("next")}
-                prevLabel={tTutorial("prev")}
+                prevLabel={tTutorial("previous")}
                 doneLabel={tTutorial("done")}
                 steps={[
                     {

--- a/src/app/(protected)/yearly-calendar/components/yearly-calendar-header.tsx
+++ b/src/app/(protected)/yearly-calendar/components/yearly-calendar-header.tsx
@@ -30,7 +30,7 @@ export function YearlyCalendarHeader({ translations, yearlyBalance }: YearlyCale
 
     return (
         <div className="flex items-center justify-between gap-3 shrink-0">
-            <div className="flex items-center gap-2">
+            <div id="yearly-nav-controls" className="flex items-center gap-2">
                 <Button variant="outline" size="sm" onClick={goToPreviousYear}>
                     <ChevronLeft className="h-4 w-4" />
                 </Button>
@@ -53,7 +53,7 @@ export function YearlyCalendarHeader({ translations, yearlyBalance }: YearlyCale
                     </SelectContent>
                 </Select>
             </div>
-            <div className="flex items-center gap-2">
+            <div id="yearly-balance" className="flex items-center gap-2">
                 <span className="text-sm text-muted-foreground hidden sm:inline">
                     Total Balance:
                 </span>

--- a/src/app/(protected)/yearly-calendar/components/yearly-calendar-table.tsx
+++ b/src/app/(protected)/yearly-calendar/components/yearly-calendar-table.tsx
@@ -58,7 +58,7 @@ export function YearlyCalendarTable({
     const days = Array.from({ length: 31 }, (_, i) => i + 1)
 
     return (
-        <div className="border rounded-lg overflow-auto h-full">
+        <div id="yearly-table" className="border rounded-lg overflow-auto h-full">
             <Table className="h-full">
                 <colgroup>
                     <col style={{ width: "120px", minWidth: "120px" }} />
@@ -115,7 +115,7 @@ export function YearlyCalendarTable({
                                     return (
                                         <TableCell
                                             key={day}
-                                            className={`p-0.5 text-center align-middle ${bgClass} ${hasData ? "cursor-pointer hover:ring-2 hover:ring-primary" : ""}`}
+                                            className={`p-0.5 text-center align-middle ${bgClass} ${hasData ? "yearly-cell cursor-pointer hover:ring-2 hover:ring-primary" : ""}`}
                                             onClick={() => handleCellClick(dateKey, hasData)}
                                         >
                                             {hasData && (

--- a/src/app/(protected)/yearly-calendar/page.tsx
+++ b/src/app/(protected)/yearly-calendar/page.tsx
@@ -7,10 +7,16 @@ import { calculateExpectedHoursToDate } from "@/lib/balance-helpers"
 import { prisma } from "@/lib/prisma"
 import { getServerSession } from "next-auth"
 import { authConfig } from "@/lib/auth"
+import { getTutorialsSeen, PageTour } from "@/features/tutorial"
 
 export default async function YearlyCalendarPage() {
-    const t = await getTranslations("yearlyCalendar")
-    const tTimeSheets = await getTranslations("timeSheets.dayEntriesDialog")
+    const [t, tTimeSheets, tutorialsSeen, tTutorial, tYearlyCal] = await Promise.all([
+        getTranslations("yearlyCalendar"),
+        getTranslations("timeSheets.dayEntriesDialog"),
+        getTutorialsSeen(),
+        getTranslations("tutorial"),
+        getTranslations("tutorial.yearlyCalendar"),
+    ])
 
     const session = await getServerSession(authConfig)
     if (!session?.user?.id) {
@@ -74,6 +80,39 @@ export default async function YearlyCalendarPage() {
 
     return (
         <div className="flex flex-col gap-4 h-full">
+            <PageTour
+                pageKey="/yearly-calendar"
+                seenPages={tutorialsSeen}
+                nextLabel={tTutorial("next")}
+                prevLabel={tTutorial("previous")}
+                doneLabel={tTutorial("done")}
+                steps={[
+                    {
+                        element: "#yearly-nav-controls",
+                        title: tYearlyCal("navigation.title"),
+                        description: tYearlyCal("navigation.description"),
+                        side: "bottom",
+                    },
+                    {
+                        element: "#yearly-balance",
+                        title: tYearlyCal("balance.title"),
+                        description: tYearlyCal("balance.description"),
+                        side: "bottom",
+                    },
+                    {
+                        element: "#yearly-table",
+                        title: tYearlyCal("calendar.title"),
+                        description: tYearlyCal("calendar.description"),
+                        side: "top",
+                    },
+                    {
+                        element: ".yearly-cell",
+                        title: tYearlyCal("cell.title"),
+                        description: tYearlyCal("cell.description"),
+                        side: "top",
+                    },
+                ]}
+            />
             <YearlyCalendarClient
                 initialYear={currentYear}
                 initialData={initialData}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "tw-animate-css";
+@import "../features/tutorial/tour.css";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/src/features/sidebar/app-header.tsx
+++ b/src/features/sidebar/app-header.tsx
@@ -30,6 +30,7 @@ export async function AppHeader({ breadcrumbTranslations }: AppHeaderProps) {
         settings: t("menu.settings"),
         language: t("menu.language"),
         theme: t("menu.theme"),
+        restartTutorial: t("menu.restartTutorial"),
         profile: tNav("profile"),
         logout: tCommon("logOut"),
     }

--- a/src/features/sidebar/settings-menu.tsx
+++ b/src/features/sidebar/settings-menu.tsx
@@ -19,7 +19,7 @@ import { signOut } from "next-auth/react"
 import { locales, localeNames, type Locale } from "@/features/locale/config"
 import { resetTutorialSeen } from "@/features/tutorial"
 
-const TUTORIAL_PAGES = new Set(["/tracker", "/time-sheets", "/shifts", "/yearly-calendar", "/hours", "/requests"])
+const TUTORIAL_PAGES = new Set(["/tracker", "/time-sheets", "/shifts", "/yearly-calendar", "/hours", "/requests", "/urnik-net-overview", "/urnik-net-overview/requests", "/urnik-net-overview/hours"])
 
 function getTutorialPageKey(pathname: string): string | null {
     if (pathname === "/tasks") return "/tasks"

--- a/src/features/sidebar/settings-menu.tsx
+++ b/src/features/sidebar/settings-menu.tsx
@@ -21,6 +21,12 @@ import { resetTutorialSeen } from "@/features/tutorial"
 
 const TUTORIAL_PAGES = new Set(["/tracker", "/time-sheets"])
 
+function getTutorialPageKey(pathname: string): string | null {
+    if (pathname === "/tasks") return "/tasks"
+    if (pathname.startsWith("/tasks/")) return "/tasks/list"
+    return TUTORIAL_PAGES.has(pathname) ? pathname : null
+}
+
 interface SettingsMenuProps {
     translations: {
         settings: string
@@ -39,7 +45,7 @@ export function SettingsMenu({ translations }: SettingsMenuProps) {
     const theme = useThemeStore((state) => state.theme)
     const setTheme = useThemeStore((state) => state.setTheme)
 
-    const tutorialPageKey = TUTORIAL_PAGES.has(pathname) ? pathname : null
+    const tutorialPageKey = getTutorialPageKey(pathname)
 
     const handleLocaleChange = async (newLocale: Locale) => {
         const response = await fetch("/api/set-locale", {

--- a/src/features/sidebar/settings-menu.tsx
+++ b/src/features/sidebar/settings-menu.tsx
@@ -1,13 +1,14 @@
 "use client"
 
-import { Settings, UserCircle, LogOut, Languages, Palette, Check } from "lucide-react"
+import { Settings, UserCircle, LogOut, Languages, Palette, Check, GraduationCap } from "lucide-react"
 import { useLocale } from "next-intl"
-import { useRouter } from "next/navigation"
+import { useRouter, usePathname } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import {
     DropdownMenu,
     DropdownMenuContent,
     DropdownMenuItem,
+    DropdownMenuSeparator,
     DropdownMenuSub,
     DropdownMenuSubContent,
     DropdownMenuSubTrigger,
@@ -16,6 +17,9 @@ import {
 import { useThemeStore } from "@/features/theme/stores/theme-store"
 import { signOut } from "next-auth/react"
 import { locales, localeNames, type Locale } from "@/features/locale/config"
+import { resetTutorialSeen } from "@/features/tutorial"
+
+const TUTORIAL_PAGES = new Set(["/tracker"])
 
 interface SettingsMenuProps {
     translations: {
@@ -24,14 +28,18 @@ interface SettingsMenuProps {
         theme: string
         profile: string
         logout: string
+        restartTutorial: string
     }
 }
 
 export function SettingsMenu({ translations }: SettingsMenuProps) {
     const locale = useLocale() as Locale
     const router = useRouter()
+    const pathname = usePathname()
     const theme = useThemeStore((state) => state.theme)
     const setTheme = useThemeStore((state) => state.setTheme)
+
+    const tutorialPageKey = TUTORIAL_PAGES.has(pathname) ? pathname : null
 
     const handleLocaleChange = async (newLocale: Locale) => {
         const response = await fetch("/api/set-locale", {
@@ -42,6 +50,12 @@ export function SettingsMenu({ translations }: SettingsMenuProps) {
         if (response.ok) {
             router.refresh()
         }
+    }
+
+    const handleRestartTutorial = async () => {
+        if (!tutorialPageKey) return
+        await resetTutorialSeen(tutorialPageKey)
+        router.refresh()
     }
 
     const themeOptions = [
@@ -100,6 +114,16 @@ export function SettingsMenu({ translations }: SettingsMenuProps) {
                     <UserCircle className="mr-2 h-4 w-4" />
                     <span>{translations.profile}</span>
                 </DropdownMenuItem>
+                {tutorialPageKey && (
+                    <>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem onClick={handleRestartTutorial}>
+                            <GraduationCap className="mr-2 h-4 w-4" />
+                            <span>{translations.restartTutorial}</span>
+                        </DropdownMenuItem>
+                    </>
+                )}
+                <DropdownMenuSeparator />
                 <DropdownMenuItem onClick={() => signOut({ callbackUrl: "/login" })}>
                     <LogOut className="mr-2 h-4 w-4" />
                     <span>{translations.logout}</span>

--- a/src/features/sidebar/settings-menu.tsx
+++ b/src/features/sidebar/settings-menu.tsx
@@ -19,7 +19,7 @@ import { signOut } from "next-auth/react"
 import { locales, localeNames, type Locale } from "@/features/locale/config"
 import { resetTutorialSeen } from "@/features/tutorial"
 
-const TUTORIAL_PAGES = new Set(["/tracker", "/time-sheets", "/shifts"])
+const TUTORIAL_PAGES = new Set(["/tracker", "/time-sheets", "/shifts", "/yearly-calendar"])
 
 function getTutorialPageKey(pathname: string): string | null {
     if (pathname === "/tasks") return "/tasks"

--- a/src/features/sidebar/settings-menu.tsx
+++ b/src/features/sidebar/settings-menu.tsx
@@ -19,7 +19,7 @@ import { signOut } from "next-auth/react"
 import { locales, localeNames, type Locale } from "@/features/locale/config"
 import { resetTutorialSeen } from "@/features/tutorial"
 
-const TUTORIAL_PAGES = new Set(["/tracker", "/time-sheets", "/shifts", "/yearly-calendar"])
+const TUTORIAL_PAGES = new Set(["/tracker", "/time-sheets", "/shifts", "/yearly-calendar", "/hours"])
 
 function getTutorialPageKey(pathname: string): string | null {
     if (pathname === "/tasks") return "/tasks"

--- a/src/features/sidebar/settings-menu.tsx
+++ b/src/features/sidebar/settings-menu.tsx
@@ -19,7 +19,7 @@ import { signOut } from "next-auth/react"
 import { locales, localeNames, type Locale } from "@/features/locale/config"
 import { resetTutorialSeen } from "@/features/tutorial"
 
-const TUTORIAL_PAGES = new Set(["/tracker", "/time-sheets", "/shifts", "/yearly-calendar", "/hours"])
+const TUTORIAL_PAGES = new Set(["/tracker", "/time-sheets", "/shifts", "/yearly-calendar", "/hours", "/requests"])
 
 function getTutorialPageKey(pathname: string): string | null {
     if (pathname === "/tasks") return "/tasks"

--- a/src/features/sidebar/settings-menu.tsx
+++ b/src/features/sidebar/settings-menu.tsx
@@ -19,7 +19,7 @@ import { signOut } from "next-auth/react"
 import { locales, localeNames, type Locale } from "@/features/locale/config"
 import { resetTutorialSeen } from "@/features/tutorial"
 
-const TUTORIAL_PAGES = new Set(["/tracker"])
+const TUTORIAL_PAGES = new Set(["/tracker", "/time-sheets"])
 
 interface SettingsMenuProps {
     translations: {

--- a/src/features/sidebar/settings-menu.tsx
+++ b/src/features/sidebar/settings-menu.tsx
@@ -1,6 +1,14 @@
 "use client"
 
-import { Settings, UserCircle, LogOut, Languages, Palette, Check, GraduationCap } from "lucide-react"
+import {
+    Settings,
+    UserCircle,
+    LogOut,
+    Languages,
+    Palette,
+    Check,
+    GraduationCap,
+} from "lucide-react"
 import { useLocale } from "next-intl"
 import { useRouter, usePathname } from "next/navigation"
 import { Button } from "@/components/ui/button"
@@ -19,11 +27,29 @@ import { signOut } from "next-auth/react"
 import { locales, localeNames, type Locale } from "@/features/locale/config"
 import { resetTutorialSeen } from "@/features/tutorial"
 
-const TUTORIAL_PAGES = new Set(["/tracker", "/time-sheets", "/shifts", "/yearly-calendar", "/hours", "/requests", "/urnik-net-overview", "/urnik-net-overview/requests", "/urnik-net-overview/hours"])
+const TUTORIAL_PAGES = new Set([
+    "/tracker",
+    "/time-sheets",
+    "/shifts",
+    "/yearly-calendar",
+    "/hours",
+    "/requests",
+    "/urnik-net-overview",
+    "/urnik-net-overview/requests",
+    "/urnik-net-overview/hours",
+    "/admin",
+    "/admin/users",
+    "/admin/holidays",
+    "/admin/pending-requests",
+    "/admin/request-history",
+    "/admin/dev",
+])
 
 function getTutorialPageKey(pathname: string): string | null {
     if (pathname === "/tasks") return "/tasks"
     if (pathname.startsWith("/tasks/")) return "/tasks/list"
+    if (pathname.startsWith("/admin/users/") && pathname !== "/admin/users")
+        return "/admin/users/detail"
     return TUTORIAL_PAGES.has(pathname) ? pathname : null
 }
 

--- a/src/features/sidebar/settings-menu.tsx
+++ b/src/features/sidebar/settings-menu.tsx
@@ -19,7 +19,7 @@ import { signOut } from "next-auth/react"
 import { locales, localeNames, type Locale } from "@/features/locale/config"
 import { resetTutorialSeen } from "@/features/tutorial"
 
-const TUTORIAL_PAGES = new Set(["/tracker", "/time-sheets"])
+const TUTORIAL_PAGES = new Set(["/tracker", "/time-sheets", "/shifts"])
 
 function getTutorialPageKey(pathname: string): string | null {
     if (pathname === "/tasks") return "/tasks"

--- a/src/features/tutorial/actions/tutorial-actions.ts
+++ b/src/features/tutorial/actions/tutorial-actions.ts
@@ -31,3 +31,14 @@ export async function markTutorialSeen(pageKey: string): Promise<void> {
         update: {},
     })
 }
+
+export async function resetTutorialSeen(pageKey: string): Promise<void> {
+    const session = await requireAuth()
+
+    await prisma.tutorialSeen.deleteMany({
+        where: {
+            userId: session.user.id,
+            pageKey,
+        },
+    })
+}

--- a/src/features/tutorial/actions/tutorial-actions.ts
+++ b/src/features/tutorial/actions/tutorial-actions.ts
@@ -1,0 +1,33 @@
+"use server"
+
+import { requireAuth } from "@/lib/auth-helpers"
+import { prisma } from "@/lib/prisma"
+
+export async function getTutorialsSeen(): Promise<string[]> {
+    const session = await requireAuth()
+
+    const rows = await prisma.tutorialSeen.findMany({
+        where: { userId: session.user.id },
+        select: { pageKey: true },
+    })
+
+    return rows.map((r) => r.pageKey)
+}
+
+export async function markTutorialSeen(pageKey: string): Promise<void> {
+    const session = await requireAuth()
+
+    await prisma.tutorialSeen.upsert({
+        where: {
+            userId_pageKey: {
+                userId: session.user.id,
+                pageKey,
+            },
+        },
+        create: {
+            userId: session.user.id,
+            pageKey,
+        },
+        update: {},
+    })
+}

--- a/src/features/tutorial/components/page-tour.tsx
+++ b/src/features/tutorial/components/page-tour.tsx
@@ -13,8 +13,6 @@ interface PageTourProps {
     nextLabel: string
     prevLabel: string
     doneLabel: string
-    skipLabel: string
-    progressLabel: string
 }
 
 export function PageTour({
@@ -24,15 +22,13 @@ export function PageTour({
     nextLabel,
     prevLabel,
     doneLabel,
-    skipLabel,
-    progressLabel,
 }: PageTourProps) {
     useEffect(() => {
         if (seenPages.includes(pageKey)) return
 
         const driverObj = driver({
             showProgress: true,
-            progressText: progressLabel,
+            progressText: "{{current}} / {{total}}",
             nextBtnText: nextLabel,
             prevBtnText: prevLabel,
             doneBtnText: doneLabel,
@@ -52,5 +48,9 @@ export function PageTour({
         })
 
         driverObj.drive()
-    }, []) // eslint-disable-line react-hooks/exhaustive-deps
+    // seenPages changing means the server re-fetched — re-run to start the tour
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [seenPages])
+
+    return null
 }

--- a/src/features/tutorial/components/page-tour.tsx
+++ b/src/features/tutorial/components/page-tour.tsx
@@ -1,0 +1,56 @@
+"use client"
+
+import { useEffect } from "react"
+import { driver } from "driver.js"
+import "driver.js/dist/driver.css"
+import { markTutorialSeen } from "../actions/tutorial-actions"
+import type { TourStep } from "../types"
+
+interface PageTourProps {
+    pageKey: string
+    seenPages: string[]
+    steps: TourStep[]
+    nextLabel: string
+    prevLabel: string
+    doneLabel: string
+    skipLabel: string
+    progressLabel: string
+}
+
+export function PageTour({
+    pageKey,
+    seenPages,
+    steps,
+    nextLabel,
+    prevLabel,
+    doneLabel,
+    skipLabel,
+    progressLabel,
+}: PageTourProps) {
+    useEffect(() => {
+        if (seenPages.includes(pageKey)) return
+
+        const driverObj = driver({
+            showProgress: true,
+            progressText: progressLabel,
+            nextBtnText: nextLabel,
+            prevBtnText: prevLabel,
+            doneBtnText: doneLabel,
+            allowClose: true,
+            steps: steps.map((s) => ({
+                element: s.element,
+                popover: {
+                    title: s.title,
+                    description: s.description,
+                    side: s.side,
+                },
+            })),
+            onDestroyStarted: () => {
+                markTutorialSeen(pageKey).catch(console.error)
+                driverObj.destroy()
+            },
+        })
+
+        driverObj.drive()
+    }, []) // eslint-disable-line react-hooks/exhaustive-deps
+}

--- a/src/features/tutorial/components/page-tour.tsx
+++ b/src/features/tutorial/components/page-tour.tsx
@@ -51,8 +51,8 @@ export function PageTour({
         })
 
         driverObj.drive()
-    // seenPages changing means the server re-fetched — re-run to start the tour
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+        // seenPages changing means the server re-fetched — re-run to start the tour
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [seenPages])
 
     return null

--- a/src/features/tutorial/components/page-tour.tsx
+++ b/src/features/tutorial/components/page-tour.tsx
@@ -33,6 +33,9 @@ export function PageTour({
             prevBtnText: prevLabel,
             doneBtnText: doneLabel,
             allowClose: true,
+            overlayOpacity: 0.5,
+            stagePadding: 4,
+            stageRadius: 6,
             steps: steps.map((s) => ({
                 element: s.element,
                 popover: {

--- a/src/features/tutorial/index.ts
+++ b/src/features/tutorial/index.ts
@@ -1,0 +1,3 @@
+export { PageTour } from "./components/page-tour"
+export { getTutorialsSeen, markTutorialSeen } from "./actions/tutorial-actions"
+export type { TourStep } from "./types"

--- a/src/features/tutorial/index.ts
+++ b/src/features/tutorial/index.ts
@@ -1,3 +1,3 @@
 export { PageTour } from "./components/page-tour"
-export { getTutorialsSeen, markTutorialSeen } from "./actions/tutorial-actions"
+export { getTutorialsSeen, markTutorialSeen, resetTutorialSeen } from "./actions/tutorial-actions"
 export type { TourStep } from "./types"

--- a/src/features/tutorial/tour.css
+++ b/src/features/tutorial/tour.css
@@ -90,5 +90,16 @@
 }
 
 .driver-overlay {
-    background: rgb(0 0 0 / 0.6) !important;
+    background: rgb(0 0 0 / 0.5) !important;
+}
+
+.driver-active-element {
+    position: relative !important;
+    z-index: 10002 !important;
+}
+
+#driver-highlighted-element-stage {
+    outline: 3px solid var(--primary) !important;
+    outline-offset: 0px !important;
+    border-radius: 6px !important;
 }

--- a/src/features/tutorial/tour.css
+++ b/src/features/tutorial/tour.css
@@ -1,0 +1,94 @@
+.driver-popover {
+    background-color: var(--popover) !important;
+    color: var(--popover-foreground) !important;
+    border: 1px solid var(--border) !important;
+    border-radius: var(--radius) !important;
+    box-shadow:
+        0 4px 6px -1px rgb(0 0 0 / 0.1),
+        0 2px 4px -2px rgb(0 0 0 / 0.1) !important;
+    padding: 1rem !important;
+    min-width: 220px !important;
+    max-width: 320px !important;
+}
+
+.driver-popover-title {
+    font-size: 0.875rem !important;
+    font-weight: 600 !important;
+    color: var(--popover-foreground) !important;
+    margin-bottom: 0.375rem !important;
+}
+
+.driver-popover-description {
+    font-size: 0.8125rem !important;
+    color: var(--muted-foreground) !important;
+    line-height: 1.5 !important;
+}
+
+.driver-popover-progress-text {
+    font-size: 0.75rem !important;
+    color: var(--muted-foreground) !important;
+}
+
+.driver-popover-footer {
+    margin-top: 0.75rem !important;
+    gap: 0.375rem !important;
+}
+
+.driver-popover-prev-btn,
+.driver-popover-next-btn,
+.driver-popover-done-btn {
+    background-color: var(--primary) !important;
+    color: var(--primary-foreground) !important;
+    border: none !important;
+    border-radius: var(--radius-sm) !important;
+    padding: 0.25rem 0.75rem !important;
+    font-size: 0.8125rem !important;
+    font-weight: 500 !important;
+    cursor: pointer !important;
+    text-shadow: none !important;
+    box-shadow: none !important;
+}
+
+.driver-popover-prev-btn {
+    background-color: var(--secondary) !important;
+    color: var(--secondary-foreground) !important;
+}
+
+.driver-popover-prev-btn:hover,
+.driver-popover-next-btn:hover,
+.driver-popover-done-btn:hover {
+    opacity: 0.9 !important;
+}
+
+.driver-popover-close-btn {
+    color: var(--muted-foreground) !important;
+    background: none !important;
+    border: none !important;
+    font-size: 1rem !important;
+    line-height: 1 !important;
+    cursor: pointer !important;
+}
+
+.driver-popover-close-btn:hover {
+    color: var(--popover-foreground) !important;
+}
+
+.driver-popover-arrow-side-left.driver-popover-arrow {
+    border-left-color: var(--border) !important;
+}
+
+.driver-popover-arrow-side-right.driver-popover-arrow {
+    border-right-color: var(--border) !important;
+}
+
+.driver-popover-arrow-side-top.driver-popover-arrow {
+    border-top-color: var(--border) !important;
+}
+
+.driver-popover-arrow-side-bottom.driver-popover-arrow {
+    border-bottom-color: var(--border) !important;
+}
+
+.driver-overlay {
+    background: rgb(0 0 0 / 0.6) !important;
+}

--- a/src/features/tutorial/types.ts
+++ b/src/features/tutorial/types.ts
@@ -1,0 +1,6 @@
+export interface TourStep {
+    element: string
+    title: string
+    description: string
+    side?: "top" | "bottom" | "left" | "right"
+}


### PR DESCRIPTION
## Summary

Adds a full page-by-page interactive tutorial system using [driver.js](https://driverjs.com/). Each page has a guided tour that highlights key UI elements with descriptive tooltips. Tours are shown automatically on first visit and can be restarted at any time from the Settings menu in the sidebar.

---

## Infrastructure

- **`src/features/tutorial/`** — new feature module:
  - `components/page-tour.tsx` — server component that conditionally renders the tour based on DB-backed seen state
  - `actions/tutorial-actions.ts` — server actions: `getTutorialsSeen`, `markTutorialSeen`, `resetTutorialSeen`
  - `types.ts` — flat `TourStep` type (`element`, `title`, `description`, `side`)
  - `tour.css` — custom driver.js overrides (overlay opacity, stage radius, padding)
  - `index.ts` — barrel export
- **`settings-menu.tsx`** — "Restart Tutorial" button added; `getTutorialPageKey()` resolves the current pathname to a tour key, including special cases for `/tasks/[listId]` and `/admin/users/[id]`
- **Database** — `tutorialsSeen` field on `User` stores a JSON array of seen page keys

---

## Pages with tutorials

### User-facing pages (11 tours)

| Page | Steps |
|---|---|
| `/tracker` | Clock-in card, time entries |
| `/time-sheets` | Month nav, week table |
| `/tasks` | Task list sidebar, task board |
| `/tasks/[listId]` | List header, task columns |
| `/shifts` | Shift calendar |
| `/yearly-calendar` | Calendar grid |
| `/hours` | Hours table, controls |
| `/requests` | Controls, new request button, table |
| `/urnik-net-overview` | Summary cards, nav |
| `/urnik-net-overview/requests` | Requests table |
| `/urnik-net-overview/hours` | Month nav, summary, daily table |

### Admin pages (7 tours)

| Page | Steps |
|---|---|
| `/admin` | Stats cards, status breakdown, quick actions, recent requests, upcoming holidays |
| `/admin/users` | Toolbar (search/create), user table |
| `/admin/users/[id]` | Edit form, hours section, request history |
| `/admin/holidays` | Year nav, import button, add button, holiday table |
| `/admin/pending-requests` | Pending table |
| `/admin/request-history` | History table |
| `/admin/dev` | Test email, test push, admin push, simulate flow, subscriptions |

---

## i18n

All tour step titles and descriptions are fully translated into **English** and **Slovenian** under the `tutorial.*` namespace in `messages/en.json` and `messages/sl.json`.

---

## Changes

- 60 files changed, ~1 900 insertions, ~300 deletions
- Element IDs added to targeted components for driver.js anchoring
- All server components use `getTranslations()` (no `useTranslations` hook) to avoid hydration flicker
- Parallel `Promise.all` fetches for `getTutorialsSeen` alongside existing data fetches — no added waterfalls
