### PR TITLE
feat: Add cookie consent banner with database persistence

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1477,5 +1477,10 @@
                 "description": "List all active push notification subscriptions registered by admin users, with their device details."
             }
         }
+    },
+    "cookieConsent": {
+        "title": "We use cookies",
+        "description": "This app uses strictly necessary cookies for authentication and functional cookies to remember your preferences (language, theme, sidebar state). No tracking or advertising cookies are used.",
+        "acknowledge": "OK, I understand"
     }
 }

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -1477,5 +1477,10 @@
                 "description": "Seznam vseh aktivnih naročnin na potisna obvestila, ki so jih registrirali administratorski uporabniki, z informacijami o napravah."
             }
         }
+    },
+    "cookieConsent": {
+        "title": "Uporabljamo piškotke",
+        "description": "Ta aplikacija uporablja nujno potrebne piškotke za avtentikacijo in funkcionalne piškotke za shranjevanje vaših nastavitev (jezik, tema, stanje stranske vrstice). Piškotki za sledenje ali oglaševanje niso uporabljeni.",
+        "acknowledge": "V redu, razumem"
     }
 }

--- a/prisma/migrations/20260420000000_baseline/migration.sql
+++ b/prisma/migrations/20260420000000_baseline/migration.sql
@@ -1,4 +1,3 @@
-
 -- CreateSchema
 CREATE SCHEMA IF NOT EXISTS "public";
 
@@ -45,7 +44,6 @@ CREATE TABLE "Account" (
     "session_state" TEXT,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
-
     CONSTRAINT "Account_pkey" PRIMARY KEY ("id")
 );
 
@@ -57,7 +55,6 @@ CREATE TABLE "Session" (
     "expires" TIMESTAMP(3) NOT NULL,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
-
     CONSTRAINT "Session_pkey" PRIMARY KEY ("id")
 );
 
@@ -89,7 +86,6 @@ CREATE TABLE "User" (
     "urnikPassword" TEXT,
     "urnikUserId" TEXT,
     "lastUrnikTestAt" TIMESTAMP(3),
-
     CONSTRAINT "User_pkey" PRIMARY KEY ("id")
 );
 
@@ -104,7 +100,6 @@ CREATE TABLE "HourEntry" (
     "taskId" TEXT,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
-
     CONSTRAINT "HourEntry_pkey" PRIMARY KEY ("id")
 );
 
@@ -122,7 +117,6 @@ CREATE TABLE "Task" (
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
     "listId" TEXT,
-
     CONSTRAINT "Task_pkey" PRIMARY KEY ("id")
 );
 
@@ -137,7 +131,6 @@ CREATE TABLE "TaskTimeEntry" (
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
     "type" "HourType" NOT NULL DEFAULT 'WORK',
-
     CONSTRAINT "TaskTimeEntry_pkey" PRIMARY KEY ("id")
 );
 
@@ -168,7 +161,7 @@ CREATE TABLE "Request" (
     "isFullDay" BOOLEAN NOT NULL DEFAULT true,
     "originalEndDate" TIMESTAMP(3),
     "originalStartDate" TIMESTAMP(3),
-    "requestedHours" DECIMAL(65,30),
+    "requestedHours" DECIMAL(65, 30),
     "splitFrom" TEXT,
     "startTime" TEXT,
     "supersededBy" TEXT,
@@ -178,7 +171,6 @@ CREATE TABLE "Request" (
     "urnikNetSyncedAt" TIMESTAMP(3),
     "urnikNetRequestNo" TEXT,
     "urnikNetError" TEXT,
-
     CONSTRAINT "Request_pkey" PRIMARY KEY ("id")
 );
 
@@ -193,7 +185,6 @@ CREATE TABLE "Shift" (
     "updatedAt" TIMESTAMP(3) NOT NULL,
     "endDateTime" TIMESTAMP(3),
     "startDateTime" TIMESTAMP(3),
-
     CONSTRAINT "Shift_pkey" PRIMARY KEY ("id")
 );
 
@@ -210,7 +201,6 @@ CREATE TABLE "List" (
     "isPrivate" BOOLEAN NOT NULL DEFAULT false,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
-
     CONSTRAINT "List_pkey" PRIMARY KEY ("id")
 );
 
@@ -223,7 +213,6 @@ CREATE TABLE "Holiday" (
     "isRecurring" BOOLEAN NOT NULL DEFAULT false,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
-
     CONSTRAINT "Holiday_pkey" PRIMARY KEY ("id")
 );
 
@@ -235,7 +224,6 @@ CREATE TABLE "PushSubscription" (
     "p256dh" TEXT NOT NULL,
     "auth" TEXT NOT NULL,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-
     CONSTRAINT "PushSubscription_pkey" PRIMARY KEY ("id")
 );
 
@@ -264,7 +252,6 @@ CREATE TABLE "NotificationPreference" (
     "pushAutoCheckout" BOOLEAN NOT NULL DEFAULT true,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
-
     CONSTRAINT "NotificationPreference_pkey" PRIMARY KEY ("id")
 );
 
@@ -280,7 +267,6 @@ CREATE TABLE "Notification" (
     "metadata" JSONB,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
-
     CONSTRAINT "Notification_pkey" PRIMARY KEY ("id")
 );
 
@@ -293,9 +279,9 @@ CREATE TABLE "UserPreferences" (
     "hoursExpandedRows" JSONB DEFAULT '[]',
     "autoCheckInEnabled" BOOLEAN NOT NULL DEFAULT false,
     "autoCheckOutEnabled" BOOLEAN NOT NULL DEFAULT false,
+    "cookieConsent" BOOLEAN,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
-
     CONSTRAINT "UserPreferences_pkey" PRIMARY KEY ("id")
 );
 
@@ -305,7 +291,6 @@ CREATE TABLE "TutorialSeen" (
     "userId" TEXT NOT NULL,
     "pageKey" TEXT NOT NULL,
     "seenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-
     CONSTRAINT "TutorialSeen_pkey" PRIMARY KEY ("id")
 );
 
@@ -315,7 +300,6 @@ CREATE TABLE "AutoCheckoutCancellation" (
     "userId" TEXT NOT NULL,
     "date" TIMESTAMP(3) NOT NULL,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-
     CONSTRAINT "AutoCheckoutCancellation_pkey" PRIMARY KEY ("id")
 );
 
@@ -328,7 +312,6 @@ CREATE TABLE "WorkTimeAdjustment" (
     "adjustedEndTime" TEXT,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
-
     CONSTRAINT "WorkTimeAdjustment_pkey" PRIMARY KEY ("id")
 );
 
@@ -351,262 +334,299 @@ CREATE TABLE "UrnikRequest" (
     "urnikRequestNo" TEXT,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
-
     CONSTRAINT "UrnikRequest_pkey" PRIMARY KEY ("id")
 );
 
 -- CreateIndex
-CREATE UNIQUE INDEX "Account_provider_providerAccountId_key" ON "Account"("provider", "providerAccountId");
+CREATE UNIQUE INDEX "Account_provider_providerAccountId_key" ON "Account" (
+    "provider",
+    "providerAccountId"
+);
 
 -- CreateIndex
-CREATE UNIQUE INDEX "Session_sessionToken_key" ON "Session"("sessionToken");
+CREATE UNIQUE INDEX "Session_sessionToken_key" ON "Session" ("sessionToken");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+CREATE UNIQUE INDEX "User_email_key" ON "User" ("email");
 
 -- CreateIndex
-CREATE INDEX "HourEntry_userId_idx" ON "HourEntry"("userId");
+CREATE INDEX "HourEntry_userId_idx" ON "HourEntry" ("userId");
 
 -- CreateIndex
-CREATE INDEX "HourEntry_date_idx" ON "HourEntry"("date");
+CREATE INDEX "HourEntry_date_idx" ON "HourEntry" ("date");
 
 -- CreateIndex
-CREATE INDEX "HourEntry_taskId_idx" ON "HourEntry"("taskId");
+CREATE INDEX "HourEntry_taskId_idx" ON "HourEntry" ("taskId");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "HourEntry_userId_date_type_taskId_key" ON "HourEntry"("userId", "date", "type", "taskId");
+CREATE UNIQUE INDEX "HourEntry_userId_date_type_taskId_key" ON "HourEntry" (
+    "userId",
+    "date",
+    "type",
+    "taskId"
+);
 
 -- CreateIndex
-CREATE INDEX "Task_userId_idx" ON "Task"("userId");
+CREATE INDEX "Task_userId_idx" ON "Task" ("userId");
 
 -- CreateIndex
-CREATE INDEX "Task_listId_idx" ON "Task"("listId");
+CREATE INDEX "Task_listId_idx" ON "Task" ("listId");
 
 -- CreateIndex
-CREATE INDEX "Task_parentId_idx" ON "Task"("parentId");
+CREATE INDEX "Task_parentId_idx" ON "Task" ("parentId");
 
 -- CreateIndex
-CREATE INDEX "Task_userId_status_idx" ON "Task"("userId", "status");
+CREATE INDEX "Task_userId_status_idx" ON "Task" ("userId", "status");
 
 -- CreateIndex
-CREATE INDEX "Task_userId_listId_idx" ON "Task"("userId", "listId");
+CREATE INDEX "Task_userId_listId_idx" ON "Task" ("userId", "listId");
 
 -- CreateIndex
-CREATE INDEX "Task_userId_status_listId_idx" ON "Task"("userId", "status", "listId");
+CREATE INDEX "Task_userId_status_listId_idx" ON "Task" ("userId", "status", "listId");
 
 -- CreateIndex
-CREATE INDEX "Task_userId_listId_status_idx" ON "Task"("userId", "listId", "status");
+CREATE INDEX "Task_userId_listId_status_idx" ON "Task" ("userId", "listId", "status");
 
 -- CreateIndex
-CREATE INDEX "Task_id_title_status_listId_idx" ON "Task"("id", "title", "status", "listId");
+CREATE INDEX "Task_id_title_status_listId_idx" ON "Task" (
+    "id",
+    "title",
+    "status",
+    "listId"
+);
 
 -- CreateIndex
-CREATE INDEX "TaskTimeEntry_taskId_idx" ON "TaskTimeEntry"("taskId");
+CREATE INDEX "TaskTimeEntry_taskId_idx" ON "TaskTimeEntry" ("taskId");
 
 -- CreateIndex
-CREATE INDEX "TaskTimeEntry_userId_idx" ON "TaskTimeEntry"("userId");
+CREATE INDEX "TaskTimeEntry_userId_idx" ON "TaskTimeEntry" ("userId");
 
 -- CreateIndex
-CREATE INDEX "TaskTimeEntry_startTime_idx" ON "TaskTimeEntry"("startTime");
+CREATE INDEX "TaskTimeEntry_startTime_idx" ON "TaskTimeEntry" ("startTime");
 
 -- CreateIndex
-CREATE INDEX "TaskTimeEntry_userId_startTime_idx" ON "TaskTimeEntry"("userId", "startTime");
+CREATE INDEX "TaskTimeEntry_userId_startTime_idx" ON "TaskTimeEntry" ("userId", "startTime");
 
 -- CreateIndex
-CREATE INDEX "TaskTimeEntry_userId_endTime_idx" ON "TaskTimeEntry"("userId", "endTime");
+CREATE INDEX "TaskTimeEntry_userId_endTime_idx" ON "TaskTimeEntry" ("userId", "endTime");
 
 -- CreateIndex
-CREATE INDEX "TaskTimeEntry_taskId_startTime_idx" ON "TaskTimeEntry"("taskId", "startTime");
+CREATE INDEX "TaskTimeEntry_taskId_startTime_idx" ON "TaskTimeEntry" ("taskId", "startTime");
 
 -- CreateIndex
-CREATE INDEX "TaskTimeEntry_userId_startTime_type_idx" ON "TaskTimeEntry"("userId", "startTime", "type");
+CREATE INDEX "TaskTimeEntry_userId_startTime_type_idx" ON "TaskTimeEntry" ("userId", "startTime", "type");
 
 -- CreateIndex
-CREATE INDEX "Request_userId_idx" ON "Request"("userId");
+CREATE INDEX "Request_userId_idx" ON "Request" ("userId");
 
 -- CreateIndex
-CREATE INDEX "Request_status_idx" ON "Request"("status");
+CREATE INDEX "Request_status_idx" ON "Request" ("status");
 
 -- CreateIndex
-CREATE INDEX "Request_startDate_idx" ON "Request"("startDate");
+CREATE INDEX "Request_startDate_idx" ON "Request" ("startDate");
 
 -- CreateIndex
-CREATE INDEX "Request_userId_status_idx" ON "Request"("userId", "status");
+CREATE INDEX "Request_userId_status_idx" ON "Request" ("userId", "status");
 
 -- CreateIndex
-CREATE INDEX "Request_userId_createdAt_idx" ON "Request"("userId", "createdAt");
+CREATE INDEX "Request_userId_createdAt_idx" ON "Request" ("userId", "createdAt");
 
 -- CreateIndex
-CREATE INDEX "Shift_userId_idx" ON "Shift"("userId");
+CREATE INDEX "Shift_userId_idx" ON "Shift" ("userId");
 
 -- CreateIndex
-CREATE INDEX "Shift_date_idx" ON "Shift"("date");
+CREATE INDEX "Shift_date_idx" ON "Shift" ("date");
 
 -- CreateIndex
-CREATE INDEX "Shift_userId_date_idx" ON "Shift"("userId", "date");
+CREATE INDEX "Shift_userId_date_idx" ON "Shift" ("userId", "date");
 
 -- CreateIndex
-CREATE INDEX "Shift_userId_startDateTime_idx" ON "Shift"("userId", "startDateTime");
+CREATE INDEX "Shift_userId_startDateTime_idx" ON "Shift" ("userId", "startDateTime");
 
 -- CreateIndex
-CREATE INDEX "List_userId_idx" ON "List"("userId");
+CREATE INDEX "List_userId_idx" ON "List" ("userId");
 
 -- CreateIndex
-CREATE INDEX "List_userId_order_idx" ON "List"("userId", "order");
+CREATE INDEX "List_userId_order_idx" ON "List" ("userId", "order");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "List_userId_name_key" ON "List"("userId", "name");
+CREATE UNIQUE INDEX "List_userId_name_key" ON "List" ("userId", "name");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "Holiday_date_key" ON "Holiday"("date");
+CREATE UNIQUE INDEX "Holiday_date_key" ON "Holiday" ("date");
 
 -- CreateIndex
-CREATE INDEX "Holiday_date_idx" ON "Holiday"("date");
+CREATE INDEX "Holiday_date_idx" ON "Holiday" ("date");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "PushSubscription_endpoint_key" ON "PushSubscription"("endpoint");
+CREATE UNIQUE INDEX "PushSubscription_endpoint_key" ON "PushSubscription" ("endpoint");
 
 -- CreateIndex
-CREATE INDEX "PushSubscription_userId_idx" ON "PushSubscription"("userId");
+CREATE INDEX "PushSubscription_userId_idx" ON "PushSubscription" ("userId");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "VerificationToken_token_key" ON "VerificationToken"("token");
+CREATE UNIQUE INDEX "VerificationToken_token_key" ON "VerificationToken" ("token");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "VerificationToken_identifier_token_key" ON "VerificationToken"("identifier", "token");
+CREATE UNIQUE INDEX "VerificationToken_identifier_token_key" ON "VerificationToken" ("identifier", "token");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "NotificationPreference_userId_key" ON "NotificationPreference"("userId");
+CREATE UNIQUE INDEX "NotificationPreference_userId_key" ON "NotificationPreference" ("userId");
 
 -- CreateIndex
-CREATE INDEX "NotificationPreference_userId_idx" ON "NotificationPreference"("userId");
+CREATE INDEX "NotificationPreference_userId_idx" ON "NotificationPreference" ("userId");
 
 -- CreateIndex
-CREATE INDEX "Notification_userId_idx" ON "Notification"("userId");
+CREATE INDEX "Notification_userId_idx" ON "Notification" ("userId");
 
 -- CreateIndex
-CREATE INDEX "Notification_userId_read_idx" ON "Notification"("userId", "read");
+CREATE INDEX "Notification_userId_read_idx" ON "Notification" ("userId", "read");
 
 -- CreateIndex
-CREATE INDEX "Notification_createdAt_idx" ON "Notification"("createdAt");
+CREATE INDEX "Notification_createdAt_idx" ON "Notification" ("createdAt");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "UserPreferences_userId_key" ON "UserPreferences"("userId");
+CREATE UNIQUE INDEX "UserPreferences_userId_key" ON "UserPreferences" ("userId");
 
 -- CreateIndex
-CREATE INDEX "UserPreferences_userId_idx" ON "UserPreferences"("userId");
+CREATE INDEX "UserPreferences_userId_idx" ON "UserPreferences" ("userId");
 
 -- CreateIndex
-CREATE INDEX "TutorialSeen_userId_idx" ON "TutorialSeen"("userId");
+CREATE INDEX "TutorialSeen_userId_idx" ON "TutorialSeen" ("userId");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "TutorialSeen_userId_pageKey_key" ON "TutorialSeen"("userId", "pageKey");
+CREATE UNIQUE INDEX "TutorialSeen_userId_pageKey_key" ON "TutorialSeen" ("userId", "pageKey");
 
 -- CreateIndex
-CREATE INDEX "AutoCheckoutCancellation_userId_idx" ON "AutoCheckoutCancellation"("userId");
+CREATE INDEX "AutoCheckoutCancellation_userId_idx" ON "AutoCheckoutCancellation" ("userId");
 
 -- CreateIndex
-CREATE INDEX "AutoCheckoutCancellation_date_idx" ON "AutoCheckoutCancellation"("date");
+CREATE INDEX "AutoCheckoutCancellation_date_idx" ON "AutoCheckoutCancellation" ("date");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "AutoCheckoutCancellation_userId_date_key" ON "AutoCheckoutCancellation"("userId", "date");
+CREATE UNIQUE INDEX "AutoCheckoutCancellation_userId_date_key" ON "AutoCheckoutCancellation" ("userId", "date");
 
 -- CreateIndex
-CREATE INDEX "WorkTimeAdjustment_userId_idx" ON "WorkTimeAdjustment"("userId");
+CREATE INDEX "WorkTimeAdjustment_userId_idx" ON "WorkTimeAdjustment" ("userId");
 
 -- CreateIndex
-CREATE INDEX "WorkTimeAdjustment_date_idx" ON "WorkTimeAdjustment"("date");
+CREATE INDEX "WorkTimeAdjustment_date_idx" ON "WorkTimeAdjustment" ("date");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "WorkTimeAdjustment_userId_date_key" ON "WorkTimeAdjustment"("userId", "date");
+CREATE UNIQUE INDEX "WorkTimeAdjustment_userId_date_key" ON "WorkTimeAdjustment" ("userId", "date");
 
 -- CreateIndex
-CREATE INDEX "UrnikRequest_userId_idx" ON "UrnikRequest"("userId");
+CREATE INDEX "UrnikRequest_userId_idx" ON "UrnikRequest" ("userId");
 
 -- CreateIndex
-CREATE INDEX "UrnikRequest_status_idx" ON "UrnikRequest"("status");
+CREATE INDEX "UrnikRequest_status_idx" ON "UrnikRequest" ("status");
 
 -- CreateIndex
-CREATE INDEX "UrnikRequest_date_idx" ON "UrnikRequest"("date");
+CREATE INDEX "UrnikRequest_date_idx" ON "UrnikRequest" ("date");
 
 -- CreateIndex
-CREATE INDEX "UrnikRequest_category_idx" ON "UrnikRequest"("category");
+CREATE INDEX "UrnikRequest_category_idx" ON "UrnikRequest" ("category");
 
 -- AddForeignKey
-ALTER TABLE "Account" ADD CONSTRAINT "Account_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "Account"
+ADD CONSTRAINT "Account_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "Session" ADD CONSTRAINT "Session_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "Session"
+ADD CONSTRAINT "Session_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "HourEntry" ADD CONSTRAINT "HourEntry_taskId_fkey" FOREIGN KEY ("taskId") REFERENCES "Task"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "HourEntry"
+ADD CONSTRAINT "HourEntry_taskId_fkey" FOREIGN KEY ("taskId") REFERENCES "Task" ("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "HourEntry" ADD CONSTRAINT "HourEntry_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "HourEntry"
+ADD CONSTRAINT "HourEntry_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "Task" ADD CONSTRAINT "Task_listId_fkey" FOREIGN KEY ("listId") REFERENCES "List"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "Task"
+ADD CONSTRAINT "Task_listId_fkey" FOREIGN KEY ("listId") REFERENCES "List" ("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "Task" ADD CONSTRAINT "Task_parentId_fkey" FOREIGN KEY ("parentId") REFERENCES "Task"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "Task"
+ADD CONSTRAINT "Task_parentId_fkey" FOREIGN KEY ("parentId") REFERENCES "Task" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "Task" ADD CONSTRAINT "Task_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "Task"
+ADD CONSTRAINT "Task_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "TaskTimeEntry" ADD CONSTRAINT "TaskTimeEntry_taskId_fkey" FOREIGN KEY ("taskId") REFERENCES "Task"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "TaskTimeEntry"
+ADD CONSTRAINT "TaskTimeEntry_taskId_fkey" FOREIGN KEY ("taskId") REFERENCES "Task" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "TaskTimeEntry" ADD CONSTRAINT "TaskTimeEntry_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "TaskTimeEntry"
+ADD CONSTRAINT "TaskTimeEntry_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "Request" ADD CONSTRAINT "Request_approvedBy_fkey" FOREIGN KEY ("approvedBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "Request"
+ADD CONSTRAINT "Request_approvedBy_fkey" FOREIGN KEY ("approvedBy") REFERENCES "User" ("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "Request" ADD CONSTRAINT "Request_cancelledBy_fkey" FOREIGN KEY ("cancelledBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "Request"
+ADD CONSTRAINT "Request_cancelledBy_fkey" FOREIGN KEY ("cancelledBy") REFERENCES "User" ("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "Request" ADD CONSTRAINT "Request_rejectedBy_fkey" FOREIGN KEY ("rejectedBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "Request"
+ADD CONSTRAINT "Request_rejectedBy_fkey" FOREIGN KEY ("rejectedBy") REFERENCES "User" ("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "Request" ADD CONSTRAINT "Request_splitFrom_fkey" FOREIGN KEY ("splitFrom") REFERENCES "Request"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "Request"
+ADD CONSTRAINT "Request_splitFrom_fkey" FOREIGN KEY ("splitFrom") REFERENCES "Request" ("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "Request" ADD CONSTRAINT "Request_supersededBy_fkey" FOREIGN KEY ("supersededBy") REFERENCES "Request"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "Request"
+ADD CONSTRAINT "Request_supersededBy_fkey" FOREIGN KEY ("supersededBy") REFERENCES "Request" ("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "Request" ADD CONSTRAINT "Request_trimmedBy_fkey" FOREIGN KEY ("trimmedBy") REFERENCES "Request"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "Request"
+ADD CONSTRAINT "Request_trimmedBy_fkey" FOREIGN KEY ("trimmedBy") REFERENCES "Request" ("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "Request" ADD CONSTRAINT "Request_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "Request"
+ADD CONSTRAINT "Request_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "Shift" ADD CONSTRAINT "Shift_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "Shift"
+ADD CONSTRAINT "Shift_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "List" ADD CONSTRAINT "List_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "List"
+ADD CONSTRAINT "List_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "PushSubscription" ADD CONSTRAINT "PushSubscription_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "PushSubscription"
+ADD CONSTRAINT "PushSubscription_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "NotificationPreference" ADD CONSTRAINT "NotificationPreference_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "NotificationPreference"
+ADD CONSTRAINT "NotificationPreference_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "Notification" ADD CONSTRAINT "Notification_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "Notification"
+ADD CONSTRAINT "Notification_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "UserPreferences" ADD CONSTRAINT "UserPreferences_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "UserPreferences"
+ADD CONSTRAINT "UserPreferences_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "TutorialSeen" ADD CONSTRAINT "TutorialSeen_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "TutorialSeen"
+ADD CONSTRAINT "TutorialSeen_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "AutoCheckoutCancellation" ADD CONSTRAINT "AutoCheckoutCancellation_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "AutoCheckoutCancellation"
+ADD CONSTRAINT "AutoCheckoutCancellation_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "WorkTimeAdjustment" ADD CONSTRAINT "WorkTimeAdjustment_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "WorkTimeAdjustment"
+ADD CONSTRAINT "WorkTimeAdjustment_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "UrnikRequest" ADD CONSTRAINT "UrnikRequest_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
-
+ALTER TABLE "UrnikRequest"
+ADD CONSTRAINT "UrnikRequest_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -345,6 +345,7 @@ model UserPreferences {
   hoursExpandedRows    Json?    @default("[]")
   autoCheckInEnabled   Boolean  @default(false)
   autoCheckOutEnabled  Boolean  @default(false)
+  cookieConsent        Boolean?
   createdAt            DateTime @default(now())
   updatedAt            DateTime @updatedAt
   user                 User     @relation(fields: [userId], references: [id], onDelete: Cascade)

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,6 +15,7 @@ import { NextIntlClientProvider } from "next-intl"
 import { ThemeProvider } from "@/features/theme/providers/theme-provider"
 import { NavigationProgress } from "@/features/navigation/components/navigation-progress"
 import { BreadcrumbProvider } from "@/features/breadcrumbs"
+import { CookieBanner } from "@/features/cookie-consent"
 
 const geistSans = Geist({
     variable: "--font-geist-sans",
@@ -78,6 +79,13 @@ export default async function RootLayout({
     const themeColor = userTheme === "dark" ? "#000000" : "#ffffff"
 
     const t = await getTranslations("navigation")
+    const tCookie = await getTranslations("cookieConsent")
+    let cookieConsent: boolean | null = null
+    if (session) {
+        const { getCookieConsent } =
+            await import("@/features/cookie-consent/actions/cookie-consent-actions")
+        cookieConsent = await getCookieConsent()
+    }
     const breadcrumbTranslations = {
         "/tracker": t("timeTracker"),
         "/tasks": t("tasks"),
@@ -172,6 +180,14 @@ export default async function RootLayout({
                             </SessionWrapper>
                         </QueryProvider>
                         <Toaster />
+                        {session && (
+                            <CookieBanner
+                                initialConsent={cookieConsent}
+                                title={tCookie("title")}
+                                description={tCookie("description")}
+                                acknowledgeLabel={tCookie("acknowledge")}
+                            />
+                        )}
                     </ThemeProvider>
                 </NextIntlClientProvider>
             </body>

--- a/src/features/cookie-consent/actions/cookie-consent-actions.ts
+++ b/src/features/cookie-consent/actions/cookie-consent-actions.ts
@@ -1,0 +1,26 @@
+"use server"
+
+import { requireAuth } from "@/lib/auth-helpers"
+import { prisma } from "@/lib/prisma"
+
+export async function getCookieConsent(): Promise<boolean | null> {
+    try {
+        const session = await requireAuth()
+        const preferences = await prisma.userPreferences.findUnique({
+            where: { userId: session.user.id },
+            select: { cookieConsent: true },
+        })
+        return preferences?.cookieConsent ?? null
+    } catch {
+        return null
+    }
+}
+
+export async function saveCookieConsent(accepted: boolean): Promise<void> {
+    const session = await requireAuth()
+    await prisma.userPreferences.upsert({
+        where: { userId: session.user.id },
+        create: { userId: session.user.id, cookieConsent: accepted },
+        update: { cookieConsent: accepted },
+    })
+}

--- a/src/features/cookie-consent/components/cookie-banner.tsx
+++ b/src/features/cookie-consent/components/cookie-banner.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import { useState, useTransition } from "react"
+import { Button } from "@/components/ui/button"
+import { Cookie } from "lucide-react"
+import { saveCookieConsent } from "../actions/cookie-consent-actions"
+
+interface CookieBannerProps {
+    initialConsent: boolean | null
+    title: string
+    description: string
+    acknowledgeLabel: string
+}
+
+export function CookieBanner({
+    initialConsent,
+    title,
+    description,
+    acknowledgeLabel,
+}: CookieBannerProps) {
+    const [visible, setVisible] = useState(initialConsent === null)
+    const [isPending, startTransition] = useTransition()
+
+    function handleAcknowledge() {
+        startTransition(async () => {
+            await saveCookieConsent(true)
+            setVisible(false)
+        })
+    }
+
+    if (!visible) return null
+
+    return (
+        <div className="fixed bottom-0 left-0 right-0 z-50 p-4 sm:p-6">
+            <div className="mx-auto max-w-2xl rounded-xl border bg-background shadow-lg">
+                <div className="flex flex-col gap-4 p-4 sm:flex-row sm:items-start sm:p-5">
+                    <Cookie className="mt-0.5 size-5 shrink-0 text-muted-foreground" />
+                    <div className="flex flex-1 flex-col gap-3">
+                        <div>
+                            <p className="text-sm font-semibold">{title}</p>
+                            <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+                        </div>
+                        <div className="flex flex-wrap gap-2">
+                            <Button size="sm" disabled={isPending} onClick={handleAcknowledge}>
+                                {acknowledgeLabel}
+                            </Button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/src/features/cookie-consent/index.ts
+++ b/src/features/cookie-consent/index.ts
@@ -1,0 +1,1 @@
+export { CookieBanner } from "./components/cookie-banner"


### PR DESCRIPTION
## Summary

Adds a cookie consent notice banner that appears for authenticated users who have not yet acknowledged it.

## Changes

- **Database**: Added `cookieConsent Boolean?` field to `UserPreferences` model (schema + baseline migration updated, column applied to existing DB)
- **Server action** (`cookie-consent-actions.ts`): `getCookieConsent()` reads consent from DB, `saveCookieConsent()` upserts it
- **Banner component** (`cookie-banner.tsx`): Fixed bottom banner with a single "OK, I understand" button — no localStorage, consent persists per user in the database
- **Translations**: Added `cookieConsent` keys to both `en.json` and `sl.json`
- **Root layout**: Reads consent server-side and passes it to the banner; banner only renders for authenticated users

## Behavior

- Banner appears once per user (when `cookieConsent` is `null`)
- Clicking "OK, I understand" saves `cookieConsent: true` to the database and dismisses the banner
- No decline option — all cookies used are strictly necessary or functional (no tracking/advertising cookies)