### PR TITLE
fix: Fix auto clock-in/out cron not executing due to missing session

### DIFF
--- a/src/app/(protected)/urnik-net-overview/actions/auto-clock-actions.ts
+++ b/src/app/(protected)/urnik-net-overview/actions/auto-clock-actions.ts
@@ -1,7 +1,7 @@
 "use server"
 
 import { prisma } from "@/lib/prisma"
-import { clockInToUrnik, clockOutFromUrnik } from "./clock-actions"
+import { performClockInWithCookie, performClockOutWithCookie } from "./clock-actions"
 import {
     notifyAutoCheckinReminder,
     notifyAutoCheckinCompleted,
@@ -139,7 +139,7 @@ export async function processAutoCheckin(userId: string): Promise<ActionResult> 
         })
 
         const isWorkFromHome = !!wfhRequest
-        const clockInResult = await clockInToUrnik(isWorkFromHome)
+        const clockInResult = await performClockInWithCookie(cookie, isWorkFromHome)
 
         if (!clockInResult.success) {
             return { success: false, error: clockInResult.error || "Failed to clock in" }
@@ -206,7 +206,7 @@ export async function processAutoCheckout(userId: string): Promise<ActionResult>
             return { success: false, error: "Failed to authenticate with urnik.net" }
         }
 
-        const clockOutResult = await clockOutFromUrnik()
+        const clockOutResult = await performClockOutWithCookie(cookie)
 
         if (!clockOutResult.success) {
             return { success: false, error: clockOutResult.error || "Failed to clock out" }

--- a/src/app/(protected)/urnik-net-overview/actions/clock-actions.ts
+++ b/src/app/(protected)/urnik-net-overview/actions/clock-actions.ts
@@ -157,6 +157,78 @@ export async function getTodayDayInfo(): Promise<DayInfoResult> {
     }
 }
 
+export async function performClockInWithCookie(cookie: string, isWorkFromHome: boolean = false) {
+    const clockInType = isWorkFromHome ? "14" : "0"
+    const response = await fetch(
+        `https://urnik.net/App/Main?handler=SetTimeInNow&rid=null&ClockInType=${clockInType}`,
+        {
+            method: "GET",
+            headers: {
+                "User-Agent": URNIK_USER_AGENT,
+                Cookie: cookie,
+                "X-Requested-With": "XMLHttpRequest",
+                Accept: "application/json, text/javascript, */*; q=0.01",
+                "Accept-Language": "en-GB,en;q=0.9,sl;q=0.8",
+                Origin: "https://urnik.net",
+                Referer: "https://urnik.net/App/Main",
+            },
+        }
+    )
+
+    if (!response.ok) {
+        return { success: false, error: `Request failed: ${response.status}` }
+    }
+
+    const responseText = await response.text()
+
+    let responseData
+    try {
+        responseData = JSON.parse(responseText)
+    } catch {
+        return { success: true, message: "Clocked in successfully" }
+    }
+
+    if (responseData.res === false && responseData.msg) {
+        return { success: false, error: responseData.msg }
+    }
+
+    return { success: true, message: "Clocked in successfully" }
+}
+
+export async function performClockOutWithCookie(cookie: string) {
+    const response = await fetch("https://urnik.net/App/Main?handler=SetTimeOutPicker&type=0", {
+        method: "GET",
+        headers: {
+            "User-Agent": URNIK_USER_AGENT,
+            Cookie: cookie,
+            "X-Requested-With": "XMLHttpRequest",
+            Accept: "application/json, text/javascript, */*; q=0.01",
+            "Accept-Language": "en-GB,en;q=0.9,sl;q=0.8",
+            Origin: "https://urnik.net",
+            Referer: "https://urnik.net/App/Main",
+        },
+    })
+
+    if (!response.ok) {
+        return { success: false, error: `Request failed: ${response.status}` }
+    }
+
+    const responseText = await response.text()
+
+    let responseData
+    try {
+        responseData = JSON.parse(responseText)
+    } catch {
+        return { success: true, message: "Clocked out successfully" }
+    }
+
+    if (responseData.res === false && responseData.msg) {
+        return { success: false, error: responseData.msg }
+    }
+
+    return { success: true, message: "Clocked out successfully" }
+}
+
 export async function clockInToUrnik(isWorkFromHome: boolean = false) {
     try {
         await requireAuth()
@@ -167,42 +239,13 @@ export async function clockInToUrnik(isWorkFromHome: boolean = false) {
             return { success: false, error: "No urnik credentials or login failed" }
         }
 
-        const clockInType = isWorkFromHome ? "14" : "0"
-        const response = await fetch(
-            `https://urnik.net/App/Main?handler=SetTimeInNow&rid=null&ClockInType=${clockInType}`,
-            {
-                method: "GET",
-                headers: {
-                    "User-Agent": URNIK_USER_AGENT,
-                    Cookie: cookie,
-                    "X-Requested-With": "XMLHttpRequest",
-                    Accept: "application/json, text/javascript, */*; q=0.01",
-                    "Accept-Language": "en-GB,en;q=0.9,sl;q=0.8",
-                    Origin: "https://urnik.net",
-                    Referer: "https://urnik.net/App/Main",
-                },
-            }
-        )
+        const result = await performClockInWithCookie(cookie, isWorkFromHome)
 
-        if (!response.ok) {
-            return { success: false, error: `Request failed: ${response.status}` }
+        if (result.success) {
+            revalidatePath("/urnik-net-overview")
         }
 
-        const responseText = await response.text()
-
-        let responseData
-        try {
-            responseData = JSON.parse(responseText)
-        } catch {
-            return { success: true, message: "Clocked in successfully" }
-        }
-
-        if (responseData.res === false && responseData.msg) {
-            return { success: false, error: responseData.msg }
-        }
-
-        revalidatePath("/urnik-net-overview")
-        return { success: true, message: "Clocked in successfully" }
+        return result
     } catch (error) {
         return {
             success: false,
@@ -221,38 +264,13 @@ export async function clockOutFromUrnik() {
             return { success: false, error: "No urnik credentials or login failed" }
         }
 
-        const response = await fetch("https://urnik.net/App/Main?handler=SetTimeOutPicker&type=0", {
-            method: "GET",
-            headers: {
-                "User-Agent": URNIK_USER_AGENT,
-                Cookie: cookie,
-                "X-Requested-With": "XMLHttpRequest",
-                Accept: "application/json, text/javascript, */*; q=0.01",
-                "Accept-Language": "en-GB,en;q=0.9,sl;q=0.8",
-                Origin: "https://urnik.net",
-                Referer: "https://urnik.net/App/Main",
-            },
-        })
+        const result = await performClockOutWithCookie(cookie)
 
-        if (!response.ok) {
-            return { success: false, error: `Request failed: ${response.status}` }
+        if (result.success) {
+            revalidatePath("/urnik-net-overview")
         }
 
-        const responseText = await response.text()
-
-        let responseData
-        try {
-            responseData = JSON.parse(responseText)
-        } catch {
-            return { success: true, message: "Clocked out successfully" }
-        }
-
-        if (responseData.res === false && responseData.msg) {
-            return { success: false, error: responseData.msg }
-        }
-
-        revalidatePath("/urnik-net-overview")
-        return { success: true, message: "Clocked out successfully" }
+        return result
     } catch (error) {
         return {
             success: false,


### PR DESCRIPTION
## Problem

The auto clock-in/out cron job was sending push notifications correctly but the actual clock-in/clock-out never executed.

The root cause: `processAutoCheckin`/`processAutoCheckout` in `auto-clock-actions.ts` correctly fetched a cookie via `getUrnikCookieForUser(userId)`, but then called `clockInToUrnik()`/`clockOutFromUrnik()` which internally call `requireAuth()` and fetch their own cookie — both of which require an active Next.js session that doesn't exist in the cron process. The fetched cookie was effectively discarded.

## Fix

Extracted the raw HTTP fetch logic from `clockInToUrnik`/`clockOutFromUrnik` into two new helpers:
- `performClockInWithCookie(cookie, isWorkFromHome)`
- `performClockOutWithCookie(cookie)`

The existing `clockInToUrnik`/`clockOutFromUrnik` now delegate to these helpers (no logic duplication). `processAutoCheckin`/`processAutoCheckout` call the helpers directly with the already-fetched cookie, bypassing the session requirement entirely.