### PR TITLE
fix: Fix auto clock-in/out cron and reduce DB queries

### DIFF
--- a/scripts/auto-checkin-checkout-cron.ts
+++ b/scripts/auto-checkin-checkout-cron.ts
@@ -141,6 +141,10 @@ const lastCheckin = new Map<string, Date>()
 const lastCheckoutReminder = new Map<string, Date>()
 const lastCheckout = new Map<string, Date>()
 
+let cachedTriggers: UserTrigger[] | null = null
+let cachedTriggersAt: Date | null = null
+const TRIGGER_CACHE_TTL_MS = 60 * 60 * 1000
+
 async function processTriggers(): Promise<void> {
     try {
         const nowUtc = new Date()
@@ -148,7 +152,12 @@ async function processTriggers(): Promise<void> {
             `[processTriggers] Checking triggers at ${nowUtc.toISOString()} UTC (${nowUtc.toLocaleString("sl-SI", { timeZone: TIMEZONE })} Ljubljana)`
         )
 
-        const triggers = await getUserTriggers()
+        const cacheExpired = !cachedTriggersAt || nowUtc.getTime() - cachedTriggersAt.getTime() > TRIGGER_CACHE_TTL_MS
+        if (!cachedTriggers || cacheExpired) {
+            cachedTriggers = await getUserTriggers()
+            cachedTriggersAt = nowUtc
+        }
+        const triggers = cachedTriggers
 
         for (const trigger of triggers) {
             if (
@@ -222,6 +231,8 @@ function resetDailyTracking() {
         lastCheckin.clear()
         lastCheckoutReminder.clear()
         lastCheckout.clear()
+        cachedTriggers = null
+        cachedTriggersAt = null
     }
 }
 


### PR DESCRIPTION
## Changes

### Fix: Auto clock-in/out cron not executing
The cron was calling `clockInToUrnik`/`clockOutFromUrnik` which internally called `requireAuth()` → `getServerSession()` → Next.js `headers()`. This requires an active HTTP request context that doesn't exist in a cron process, causing the clock-in/out to always fail silently while still sending push notifications.

**Fix:** Extracted raw fetch logic into `performClockInWithCookie` and `performClockOutWithCookie` helpers that accept a cookie directly, bypassing the session entirely.

### Perf: Cache cron user triggers with 1-hour TTL
The cron was calling `prisma.user.findMany()` every 60 seconds (1,440 DB queries/day) to fetch user work schedules, even at 2am when nothing would ever trigger.

**Fix:** Cache the result in memory and only refresh once per hour (24 queries/day).