### PR TITLE
fix: Invalidate time-sheets cache after task status change

### DIFF
--- a/src/app/(protected)/tasks/actions/task-actions.ts
+++ b/src/app/(protected)/tasks/actions/task-actions.ts
@@ -228,6 +228,7 @@ export async function updateTask(input: UpdateTaskInput) {
         })
 
         revalidatePath("/tasks")
+        revalidatePath("/time-sheets")
         return { success: true }
     } catch (error) {
         if (error instanceof Error) {

--- a/src/app/(protected)/tasks/components/task-status-select.tsx
+++ b/src/app/(protected)/tasks/components/task-status-select.tsx
@@ -19,9 +19,10 @@ import type { TaskStatus } from "../schemas/task-action-schemas"
 
 interface TaskStatusSelectProps {
     task: TaskTreeNode
+    onSuccess?: () => void
 }
 
-export function TaskStatusSelect({ task }: TaskStatusSelectProps) {
+export function TaskStatusSelect({ task, onSuccess }: TaskStatusSelectProps) {
     const queryClient = useQueryClient()
     const tStatus = useTranslations("tasks.statuses")
     const setTaskOperationLoading = useTasksStore((state) => state.setTaskOperationLoading)
@@ -43,6 +44,7 @@ export function TaskStatusSelect({ task }: TaskStatusSelectProps) {
 
             if (result.success) {
                 await queryClient.invalidateQueries({ queryKey: taskKeys.all })
+                onSuccess?.()
             } else {
                 console.error("Failed to update task status:", result.error)
             }

--- a/src/app/(protected)/time-sheets/components/time-sheets-table.tsx
+++ b/src/app/(protected)/time-sheets/components/time-sheets-table.tsx
@@ -1,6 +1,7 @@
 "use client"
 
-import { useState, useMemo } from "react"
+import { useState, useMemo, useCallback } from "react"
+import { useRouter } from "next/navigation"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { Play, Square } from "lucide-react"
 import { useTranslations } from "next-intl"
@@ -71,7 +72,13 @@ export function TimeSheetsTable({
     const openDayEntriesDialog = useTimeSheetsStore((state) => state.openDayEntriesDialog)
     const setActiveTimer = useTasksStore((state) => state.setActiveTimer)
     const clearActiveTimer = useTasksStore((state) => state.clearActiveTimer)
+    const router = useRouter()
     const [loadingTask, setLoadingTask] = useState<string | null>(null)
+
+    const handleTaskStatusSuccess = useCallback(async () => {
+        await queryClient.invalidateQueries({ queryKey: timeSheetKeys.all })
+        router.refresh()
+    }, [queryClient, router])
 
     const { tasks, dates } = aggregatedData
 
@@ -273,6 +280,7 @@ export function TimeSheetsTable({
                                                                     }
                                                                 >
                                                                     <TaskStatusSelect
+                                                                        onSuccess={handleTaskStatusSuccess}
                                                                         task={{
                                                                             id: task.taskId,
                                                                             userId: "",


### PR DESCRIPTION
## Problem

When changing a task's status via the inline dropdown in the time-sheets table, the UI would not reflect the new status until time tracking was started/stopped.

**Root cause:** `updateTask` only called `revalidatePath("/tasks")`, leaving the `unstable_cache` for time-sheets stale. The `router.refresh()` call on the client re-ran the Server Component, but it still received the cached (stale) data.

## Fix

- `task-actions.ts` — added `revalidatePath("/time-sheets")` to `updateTask` so the Next.js cache is busted server-side on every task update.
- `task-status-select.tsx` — added an optional `onSuccess` callback prop.
- `time-sheets-table.tsx` — passes a `handleTaskStatusSuccess` callback to `TaskStatusSelect` that invalidates `timeSheetKeys` in TanStack Query and calls `router.refresh()` to trigger a fresh Server Component render.