### PR TITLE
fix: Auto clock delay bugs

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -40,7 +40,14 @@ self.addEventListener("notificationclick", function (event) {
                 }),
                 credentials: "include",
             })
-                .then(() => {
+                .then((response) => {
+                    if (!response.ok) {
+                        return self.registration.showNotification("Delay Failed", {
+                            body: "Could not delay work time. Please open the app and try again.",
+                            icon: "/logo.svg",
+                            badge: "/pwa/icon-192x192.png",
+                        })
+                    }
                     return self.registration.showNotification("Time Adjusted", {
                         body: `Work time delayed by ${minutes} minutes`,
                         icon: "/logo.svg",
@@ -49,6 +56,11 @@ self.addEventListener("notificationclick", function (event) {
                 })
                 .catch((error) => {
                     console.error("Failed to adjust time:", error)
+                    return self.registration.showNotification("Delay Failed", {
+                        body: "Could not delay work time. Please open the app and try again.",
+                        icon: "/logo.svg",
+                        badge: "/pwa/icon-192x192.png",
+                    })
                 })
         )
         return
@@ -70,7 +82,14 @@ self.addEventListener("notificationclick", function (event) {
                     credentials: "include",
                 }
             )
-                .then(() => {
+                .then((response) => {
+                    if (!response.ok) {
+                        return self.registration.showNotification("Cancellation Failed", {
+                            body: "Could not cancel auto clock. Please open the app and try again.",
+                            icon: "/logo.svg",
+                            badge: "/pwa/icon-192x192.png",
+                        })
+                    }
                     return self.registration.showNotification("Cancelled", {
                         body:
                             cancelType === "checkout"
@@ -82,6 +101,11 @@ self.addEventListener("notificationclick", function (event) {
                 })
                 .catch((error) => {
                     console.error("Failed to cancel:", error)
+                    return self.registration.showNotification("Cancellation Failed", {
+                        body: "Could not cancel auto clock. Please open the app and try again.",
+                        icon: "/logo.svg",
+                        badge: "/pwa/icon-192x192.png",
+                    })
                 })
         )
         return

--- a/src/app/(protected)/urnik-net-overview/actions/auto-clock-actions.ts
+++ b/src/app/(protected)/urnik-net-overview/actions/auto-clock-actions.ts
@@ -11,6 +11,16 @@ import {
 import { getUrnikCookieForUser } from "@/lib/urnik-session"
 import { requireAuth } from "@/lib/auth-helpers"
 import { sendPushNotification } from "@/features/notifications/actions/notification-actions"
+import { toZonedTime } from "date-fns-tz"
+
+const TIMEZONE = "Europe/Ljubljana"
+
+function getTodayUtc(): Date {
+    const nowInLjubljana = toZonedTime(new Date(), TIMEZONE)
+    return new Date(
+        Date.UTC(nowInLjubljana.getFullYear(), nowInLjubljana.getMonth(), nowInLjubljana.getDate())
+    )
+}
 
 interface ActionResult {
     success: boolean
@@ -20,6 +30,8 @@ interface ActionResult {
 
 export async function sendCheckinReminder(userId: string): Promise<ActionResult> {
     try {
+        const today = getTodayUtc()
+
         const user = await prisma.user.findUnique({
             where: { id: userId },
             select: {
@@ -29,6 +41,10 @@ export async function sendCheckinReminder(userId: string): Promise<ActionResult>
                     select: {
                         autoCheckInEnabled: true,
                     },
+                },
+                workTimeAdjustments: {
+                    where: { date: today },
+                    take: 1,
                 },
             },
         })
@@ -41,10 +57,13 @@ export async function sendCheckinReminder(userId: string): Promise<ActionResult>
             return { success: false, error: "Work start time not configured" }
         }
 
+        const effectiveStartTime =
+            user.workTimeAdjustments[0]?.adjustedStartTime ?? user.workStartTime
+
         await notifyAutoCheckinReminder({
             userId,
             userName: user.name || "User",
-            workStartTime: user.workStartTime,
+            workStartTime: effectiveStartTime,
         })
 
         return { success: true, message: "Check-in reminder sent" }
@@ -59,6 +78,8 @@ export async function sendCheckinReminder(userId: string): Promise<ActionResult>
 
 export async function sendCheckoutReminder(userId: string): Promise<ActionResult> {
     try {
+        const today = getTodayUtc()
+
         const user = await prisma.user.findUnique({
             where: { id: userId },
             select: {
@@ -68,6 +89,10 @@ export async function sendCheckoutReminder(userId: string): Promise<ActionResult
                     select: {
                         autoCheckOutEnabled: true,
                     },
+                },
+                workTimeAdjustments: {
+                    where: { date: today },
+                    take: 1,
                 },
             },
         })
@@ -80,10 +105,12 @@ export async function sendCheckoutReminder(userId: string): Promise<ActionResult
             return { success: false, error: "Work end time not configured" }
         }
 
+        const effectiveEndTime = user.workTimeAdjustments[0]?.adjustedEndTime ?? user.workEndTime
+
         await notifyAutoCheckoutReminder({
             userId,
             userName: user.name || "User",
-            workEndTime: user.workEndTime,
+            workEndTime: effectiveEndTime,
         })
 
         return { success: true, message: "Check-out reminder sent" }


### PR DESCRIPTION
## What was wrong

### Bug 1 — Silent failure in service worker
When tapping "Delay 15min" on a reminder notification, the service worker showed a success notification regardless of the API response status. If the session had expired (common while phone is idle), the server returned 401, the delay was never saved, but the user saw "Work time delayed by 15 minutes" anyway — causing the auto clock-in to fire at the original time.

### Bug 2 — Reminder notification showed original time after a delay
After a successful delay (e.g. 08:00 → 08:15), the follow-up reminder was sent with the original `workStartTime` from the user profile instead of the effective adjusted time, making users think the delay had not taken effect.

## Changes

- `public/sw.js`: Added `response.ok` check in the `delay-` and `cancel-auto` notification action handlers. Shows a descriptive error notification on failure instead of a false success.
- `src/app/(protected)/urnik-net-overview/actions/auto-clock-actions.ts`: `sendCheckinReminder` and `sendCheckoutReminder` now query today's `WorkTimeAdjustment` and use the effective adjusted time in the push notification body.