### PR TITLE
fix: Auto clock delay bugs

### DIFF
--- a/src/app/api/adjust-work-time-quick/route.ts
+++ b/src/app/api/adjust-work-time-quick/route.ts
@@ -74,10 +74,6 @@ export async function POST(request: NextRequest) {
                     { status: 400 }
                 )
             }
-            const adjustedStartTime = addMinutes(user.workStartTime, delayMinutes)
-            const adjustedEndTime = user.workEndTime
-                ? addMinutes(user.workEndTime, delayMinutes)
-                : undefined
 
             const existing = await prisma.workTimeAdjustment.findUnique({
                 where: { userId_date: { userId: session.user.id, date: today } },
@@ -136,9 +132,7 @@ export async function POST(request: NextRequest) {
             update: { adjustedEndTime: newEnd },
         })
 
-        const newCheckoutReminderTime = new Date(
-            parseTimeToDate(newEnd).getTime() - 15 * 60 * 1000
-        )
+        const newCheckoutReminderTime = new Date(parseTimeToDate(newEnd).getTime() - 15 * 60 * 1000)
         await prisma.autoClockState.upsert({
             where: { userId: session.user.id },
             update: { checkoutReminderFiredAt: newCheckoutReminderTime },

--- a/src/app/api/adjust-work-time-quick/route.ts
+++ b/src/app/api/adjust-work-time-quick/route.ts
@@ -3,6 +3,24 @@ import { prisma } from "@/lib/prisma"
 import { getServerSession } from "next-auth"
 import { authConfig } from "@/lib/auth"
 import { z } from "zod"
+import { fromZonedTime } from "date-fns-tz"
+
+const TIMEZONE = "Europe/Ljubljana"
+
+function parseTimeToDate(timeString: string): Date {
+    const [hours, minutes] = timeString.split(":").map(Number)
+    const nowUtc = new Date()
+    const ljubljanaDate = new Date(
+        nowUtc.getUTCFullYear(),
+        nowUtc.getUTCMonth(),
+        nowUtc.getUTCDate(),
+        hours,
+        minutes,
+        0,
+        0
+    )
+    return fromZonedTime(ljubljanaDate, TIMEZONE)
+}
 
 const QuickAdjustSchema = z.object({
     delayMinutes: z.number().int().min(1).max(120),
@@ -85,6 +103,15 @@ export async function POST(request: NextRequest) {
                 },
             })
 
+            const newCheckinReminderTime = new Date(
+                parseTimeToDate(newStart).getTime() - 15 * 60 * 1000
+            )
+            await prisma.autoClockState.upsert({
+                where: { userId: session.user.id },
+                update: { checkinReminderFiredAt: newCheckinReminderTime },
+                create: { userId: session.user.id, checkinReminderFiredAt: newCheckinReminderTime },
+            })
+
             return NextResponse.json({
                 success: true,
                 message: `Work times delayed by ${delayMinutes} minutes`,
@@ -107,6 +134,18 @@ export async function POST(request: NextRequest) {
             where: { userId_date: { userId: session.user.id, date: today } },
             create: { userId: session.user.id, date: today, adjustedEndTime: newEnd },
             update: { adjustedEndTime: newEnd },
+        })
+
+        const newCheckoutReminderTime = new Date(
+            parseTimeToDate(newEnd).getTime() - 15 * 60 * 1000
+        )
+        await prisma.autoClockState.upsert({
+            where: { userId: session.user.id },
+            update: { checkoutReminderFiredAt: newCheckoutReminderTime },
+            create: {
+                userId: session.user.id,
+                checkoutReminderFiredAt: newCheckoutReminderTime,
+            },
         })
 
         return NextResponse.json({


### PR DESCRIPTION
## Problems fixed

### 1 — Silent failure when tapping "Delay" on a notification (`public/sw.js`)
The service worker showed "Work time delayed by 15 minutes" regardless of the API response status. If the session had expired, the server returned 401, the delay was never saved, but the user got a false success. Auto clock-in then fired at the original time.

**Fix:** Check `response.ok` before showing success. Show "Delay Failed — please open the app" on error. Same fix applied to the `cancel-auto` action.

### 2 — Double reminder after a delay causing double delay (`src/app/api/adjust-work-time-quick/route.ts`)
After saving a delay (e.g. 08:00 → 08:15), the cron recalculated the new reminder time as 08:00 (08:15 − 15 min). Since `checkinReminderFiredAt` was still 07:45, `shouldTrigger(08:00, 07:45)` returned true and fired a **second** reminder. Tapping "Delay 15 min" on either notification stacked the delays, resulting in 30 min total.

**Fix:** When saving a delay, also update `checkinReminderFiredAt` (or `checkoutReminderFiredAt`) to the new reminder time so the cron won't re-fire it.

### 3 — Reminder notification showed original time after a delay (`auto-clock-actions.ts`)
After a successful delay, the follow-up reminder was sent using the original `workStartTime` from the user profile, so the notification said "Your work starts at 08:00" even after delaying to 08:15.

**Fix:** `sendCheckinReminder` and `sendCheckoutReminder` now query today's `WorkTimeAdjustment` and use the effective adjusted time in the notification body.

### 4 — `CRON_SECRET` missing from `.env.production`
The cron was logging "CRON_SECRET env var not set" since the last deploy because the variable was never in `.env.production`.

**Fix:** Added `CRON_SECRET` to `.env.production`.