### PR TITLE
fix: Correct upload paths and deploy script for server NAS storage

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -55,12 +55,12 @@ ENCRYPTION_KEY="your-encryption-key-here"
 # ===========================================
 
 # Base path for storing uploaded files (task description images, etc.)
-# Defaults to public/uploads/ which is mounted as a Docker volume
+# Defaults to public/uploads/ in the application directory
 # UPLOAD_BASE_PATH="/app/public/uploads"
 
-# Base URL for serving uploaded files
-# Defaults to /uploads
-# UPLOAD_BASE_URL="/uploads"
+# Base URL for serving uploaded files. Served by /api/uploads/[...path] GET handler.
+# Defaults to /api/uploads
+# UPLOAD_BASE_URL="/api/uploads"
 
 # Maximum upload size in megabytes (default: 10)
 # UPLOAD_MAX_SIZE_MB=10

--- a/.env.example
+++ b/.env.example
@@ -84,12 +84,12 @@ ENCRYPTION_KEY="your-64-character-hex-encryption-key-here"
 
 # Base path for storing uploaded files (task description images, etc.)
 # Defaults to public/uploads/ in the application directory
-# For production, set to a persistent location outside the deploy path:
-# UPLOAD_BASE_PATH="/home/server/uploads"
+# For production, set to a persistent location (NAS, NFS, etc.):
+# UPLOAD_BASE_PATH="/home/server/NAS/mkocevar/uploads/timeapp"
 
-# Base URL for serving uploaded files. Must match the path relative to public/.
-# Defaults to /uploads (served by Next.js from public/uploads/)
-# UPLOAD_BASE_URL="/uploads"
+# Base URL for serving uploaded files. Served by /api/uploads/[...path] GET handler.
+# Defaults to /api/uploads
+# UPLOAD_BASE_URL="/api/uploads"
 
 # Maximum upload size in megabytes (default: 10)
 # UPLOAD_MAX_SIZE_MB=10

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -79,10 +79,13 @@ echo "📝 Copying production environment file..."
 cp .env.production .next/standalone/.env
 cp .env.production .env
 
-# Ensure uploads directory exists on NAS
-UPLOAD_PATH=$(grep '^UPLOAD_BASE_PATH=' .env.production | cut -d'=' -f2- | tr -d '"')
-if [ -n "$UPLOAD_PATH" ]; then
-    mkdir -p "$UPLOAD_PATH"
+# Ensure uploads directory exists
+UPLOAD_BASE_PATH=$(grep '^UPLOAD_BASE_PATH=' .env.production | cut -d'=' -f2- | tr -d '"')
+if [ -n "$UPLOAD_BASE_PATH" ]; then
+    echo "📁 Creating uploads directory: $UPLOAD_BASE_PATH"
+    mkdir -p "$UPLOAD_BASE_PATH"
+else
+    echo "⚠️  UPLOAD_BASE_PATH not set in .env.production — uploaded images may not persist across deploys"
 fi
 
 # Run migrations if needed

--- a/src/lib/storage/local-adapter.ts
+++ b/src/lib/storage/local-adapter.ts
@@ -7,7 +7,7 @@ function getBasePath(): string {
 }
 
 function getBaseUrl(): string {
-    return process.env.UPLOAD_BASE_URL ?? "/uploads"
+    return process.env.UPLOAD_BASE_URL ?? "/api/uploads"
 }
 
 export const localAdapter: StorageAdapter = {


### PR DESCRIPTION
- Revert local adapter base URL back to /api/uploads (served by GET handler)
- Update deploy script to read UPLOAD_BASE_PATH from .env.production
- Update env example files with correct paths and NAS example